### PR TITLE
change links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Photok](fastlane/metadata/android/en-US/images/featureGraphic.jpg)
 
 [![GitHub release](https://img.shields.io/github/v/release/leonlatsch/Photok.svg?logo=github&label=GitHub)](https://github.com/leonlatsch/Photok/releases/latest)
-![Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=white&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Ddev.leonlatsch.photok%26l%3DGoogle%2520Play%26m%3D%24version)
-[![F-Droid](https://img.shields.io/f-droid/v/dev.leonlatsch.photok.svg?logo=f-droid&label=F-Droid)](https://f-droid.org/packages/com.brouken.player/)
+[![Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=white&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Ddev.leonlatsch.photok%26l%3DGoogle%2520Play%26m%3D%24version)](https://play.google.com/store/apps/details?id=dev.leonlatsch.photok)
+[![F-Droid](https://img.shields.io/f-droid/v/dev.leonlatsch.photok.svg?logo=f-droid&label=F-Droid)](https://f-droid.org/packages/dev.leonlatsch.photok/)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/leonlatsch/Photok/Android%20Build%20CI)
-![GitHub](https://img.shields.io/github/license/leonlatsch/Photok)
+[![GitHub](https://img.shields.io/github/license/leonlatsch/Photok)](./LICENSE)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/9421dd34de7f42c8b8048d60a09ab5bd)](https://www.codacy.com/gh/leonlatsch/Photok/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=leonlatsch/Photok&amp;utm_campaign=Badge_Grade)
 ![Maintenance](https://img.shields.io/maintenance/yes/2021)
 


### PR DESCRIPTION
**Description:**

Don't know whether this is intentionally done or automatically updated like the translation badges, but the links in the badges don't link to what I would expect (playstore, fdroid or license). I relinked the badges I could to the corresponding Fdroid, PlayStore or License Page. If this is not wanted, you can ignore this PR ^^


**Tasks:**
- [ ] Build CI Runs
- [ ] Code Analysis up to standards
