### PR TITLE
Fix Media Permissions on Android 13

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     package="dev.leonlatsch.photok">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportMenuDialog.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportMenuDialog.kt
@@ -16,7 +16,6 @@
 
 package dev.leonlatsch.photok.gallery.ui.importing
 
-import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
@@ -25,8 +24,9 @@ import dev.leonlatsch.photok.backup.ui.RestoreBackupDialogFragment
 import dev.leonlatsch.photok.databinding.DialogImportMenuBinding
 import dev.leonlatsch.photok.other.REQ_PERM_IMPORT_PHOTOS
 import dev.leonlatsch.photok.other.REQ_PERM_IMPORT_VIDEOS
-import dev.leonlatsch.photok.other.REQ_PERM_RESTORE
 import dev.leonlatsch.photok.other.extensions.show
+import dev.leonlatsch.photok.permissions.getReadImagesPermission
+import dev.leonlatsch.photok.permissions.getReadVideosPermission
 import dev.leonlatsch.photok.uicomponnets.Chooser
 import dev.leonlatsch.photok.uicomponnets.bindings.BindableBottomSheetDialogFragment
 import pub.devrel.easypermissions.AfterPermissionGranted
@@ -53,7 +53,7 @@ class ImportMenuDialog :
         .allowMultiple()
         .requestCode(REQ_CONTENT_PHOTOS)
         .permissionCode(REQ_PERM_IMPORT_PHOTOS)
-        .permission(Manifest.permission.READ_EXTERNAL_STORAGE)
+        .permission(getReadImagesPermission())
         .show(this)
 
     /**
@@ -69,20 +69,17 @@ class ImportMenuDialog :
         .allowMultiple()
         .requestCode(REQ_CONTENT_VIDEOS)
         .permissionCode(REQ_PERM_IMPORT_VIDEOS)
-        .permission(Manifest.permission.READ_EXTERNAL_STORAGE)
+        .permission(getReadVideosPermission())
         .show(this)
 
     /**
      * Start restoring a backup.
      * Requests permission and shows [RestoreBackupDialogFragment].
      */
-    @AfterPermissionGranted(REQ_PERM_RESTORE)
     fun startSelectBackup() = Chooser.Builder()
         .message("Select Backup")
         .mimeType("application/zip")
         .requestCode(REQ_CONTENT_BACKUP)
-        .permissionCode(REQ_PERM_RESTORE)
-        .permission(Manifest.permission.READ_EXTERNAL_STORAGE)
         .show(this)
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/SharedUrisStore.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/SharedUrisStore.kt
@@ -31,7 +31,5 @@ class SharedUrisStore {
 
     fun getUris(): List<Uri> = sharedUris.toList()
 
-    fun getUriCount(): Int = sharedUris.size
-
     fun clear() = sharedUris.clear()
 }

--- a/app/src/main/java/dev/leonlatsch/photok/main/ui/MainViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/main/ui/MainViewModel.kt
@@ -21,6 +21,7 @@ import android.net.Uri
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.leonlatsch.photok.gallery.ui.importing.SharedUrisStore
 import dev.leonlatsch.photok.uicomponnets.bindings.ObservableViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 /**
@@ -35,13 +36,12 @@ class MainViewModel @Inject constructor(
     private val sharedUrisStore: SharedUrisStore,
 ) : ObservableViewModel(app) {
 
+    val consumedUrisFromStore = MutableStateFlow(emptyList<Uri>())
+
     fun addUriToSharedUriStore(uri: Uri) = sharedUrisStore.safeAddUri(uri)
 
-    fun consumeSharedUris(): List<Uri> {
-        val sharedUris = sharedUrisStore.getUris()
+    fun consumeSharedUris() {
+        consumedUrisFromStore.value = sharedUrisStore.getUris()
         sharedUrisStore.clear()
-        return sharedUris
     }
-
-    fun getUriCountFromStore(): Int = sharedUrisStore.getUriCount()
 }

--- a/app/src/main/java/dev/leonlatsch/photok/permissions/MediaPermissions.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/permissions/MediaPermissions.kt
@@ -14,18 +14,21 @@
  *   limitations under the License.
  */
 
-package dev.leonlatsch.photok.other
+package dev.leonlatsch.photok.permissions
 
-// Encryption
-const val SHA_256 = "SHA-256"
-const val AES = "AES"
-const val AES_ALGORITHM = "AES/GCM/NoPadding"
+import android.Manifest
+import android.os.Build
 
-// Intent
-const val INTENT_PHOTO_ID = "intent.photo.id"
+fun getReadVideosPermission() =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_VIDEO
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
 
-// Permissions
-const val REQ_PERM_IMPORT_PHOTOS = 10
-const val REQ_PERM_IMPORT_VIDEOS = 11
-const val REQ_PERM_EXPORT = 12
-const val REQ_PERM_SHARED_IMPORT = 14
+fun getReadImagesPermission() =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }

--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/Chooser.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/Chooser.kt
@@ -47,7 +47,11 @@ class Chooser {
      * Or request the [permission]
      */
     fun show(fragment: Fragment) {
-        if (EasyPermissions.hasPermissions(fragment.requireContext(), permission)) {
+        if (permission == null || EasyPermissions.hasPermissions(
+                fragment.requireContext(),
+                permission
+            )
+        ) {
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
             intent.type = mimeType
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple)


### PR DESCRIPTION
**Description:**

This PR fixes #192.

Android 13 introduced new media permissions, so this PR implements them for API 33 and above.
May use Photo Picker in the Future.


**Tasks:**
- [ ] Build CI Runs
- [ ] Code Analysis up to standards
