### PR TITLE
Update runner versions to ubuntu latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: set up JDK 11
@@ -15,7 +15,7 @@ jobs:
         run: ./gradlew test
         
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: set up JDK 11

--- a/.github/workflows/build-signed-release.yml
+++ b/.github/workflows/build-signed-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-process:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     
     steps:
       # Checkout

--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-release-candidate:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     
     steps:
     

--- a/.github/workflows/translation-badges.yml
+++ b/.github/workflows/translation-badges.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-translation-badges:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**Description:**

Ubuntu 18.4 Runners where removed, so they needed an update

- Update all workflows to rrun on Ubuntu Latest


**Tasks:**
- [ ] Build CI Runs
- [ ] Code Analysis up to standards
