### PR TITLE
Revoke ACCESS_NETWORK_STATE

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,8 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" tools:node="remove"/>
+
     <application
         android:name=".BaseApplication"
         android:allowBackup="false"


### PR DESCRIPTION
**Description:**

The Exoplayer Core library requests the ACCESS_NETWORK_STATE permission by default.

With a newer release of exoplayer its possible to revoke it [commit](https://github.com/google/ExoPlayer/commit/0a74e36f7b00aacfb0110817061aed978b4dcddf)

Issue by someone having the same problem
https://github.com/google/ExoPlayer/issues/6019

closes #310 


**Tasks:**
- [x] Revoke permission
- [x] Test if video player works fine
