### PR TITLE
Fix: Error when loading sampled images

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
@@ -16,20 +16,23 @@
 
 package dev.leonlatsch.photok.imageloading.compose
 
-import android.content.Context
+import android.content.res.Resources
 import coil.ImageLoader
 import coil.fetch.Fetcher
 import coil.request.Options
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.leonlatsch.photok.imageloading.compose.model.EncryptedImageRequestData
 import dev.leonlatsch.photok.model.io.EncryptedStorageManager
 import javax.inject.Inject
 
 class EncryptedImageFetcherFactory @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val encryptedStorageManager: EncryptedStorageManager,
+    private val resources: Resources,
 ) : Fetcher.Factory<EncryptedImageRequestData> {
     override fun create(data: EncryptedImageRequestData, options: Options, imageLoader: ImageLoader): Fetcher =
-        EncryptedImageFetcher(context, encryptedStorageManager, data)
+        EncryptedImageFetcher(
+            encryptedStorageManager = encryptedStorageManager,
+            requestData = data,
+            resources = resources,
+        )
 
 }


### PR DESCRIPTION
**Description:**

- Load images as whole bitmap and not as buffered source

**Explaination**
Loading AES/GCM encrypted files buffered/sampled. Causes the stream to skip bytes which is not allowed in AES/GCM.

Since this raises the issue of crashing with very big images again. This is once of the reasons I want to overhaul the encryption some day to not use GCM anymore #204 

Fixes #330 

- [x] Confirmed working by @prosch88