### PR TITLE
Bug: Set dialog not cancelable when processing

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
@@ -72,6 +72,7 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
                     getString(R.string.process_initialize)
                 }
                 ProcessState.PROCESSING -> {
+                    isCancelable = false
                     binding.processItemsProgressIndicatorLayout.show()
                     binding.processPercentLayout.show()
                     binding.processProcessingIndicator.show()


### PR DESCRIPTION
**Description:**

Maybe INITIALIZE state was skipped in some cases. Makes sure to also set not cancelable in processing state

Fixes #369 

