### PR TITLE
Dismiss progress dialogs when done

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
@@ -81,6 +81,8 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
                 ProcessState.FINISHED -> {
                     enterFinishedOrAbortedState()
                     setStatusIcon(R.drawable.ic_check, android.R.color.holo_green_dark)
+                    // auto dismiss
+                    dismiss()
                     getString(R.string.process_finished)
                 }
                 ProcessState.ABORTED -> {


### PR DESCRIPTION
Currently a user has to click on `Close` after an action like `Importing files` is done. As this is an extra click this PR changes the code to auto close the dialog in such cases.