### PR TITLE
Raise required Android Version to Android 9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId = "dev.leonlatsch.photok"
-        minSdk = VersionCodes.N
+        minSdk = VersionCodes.P
         targetSdk = VersionCodes.VANILLA_ICE_CREAM
 
         versionCode = appVersionCode.toInt()

--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcher.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcher.kt
@@ -22,6 +22,7 @@ import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.graphics.Movie
 import android.os.Build
+import android.os.Build.VERSION_CODES
 import androidx.core.graphics.drawable.toDrawable
 import coil.decode.DataSource
 import coil.drawable.MovieDrawable
@@ -49,7 +50,7 @@ class EncryptedImageFetcher(
         inputStream ?: return null
 
         val drawable = if (requestData.mimeType == PhotoType.GIF.mimeType && requestData.playGif) {
-            if (Build.VERSION.SDK_INT >= 31) {
+            if (Build.VERSION.SDK_INT >= VERSION_CODES.S) {
                 val bytes = inputStream.readBytes()
                 val source = ImageDecoder.createSource(bytes)
                 ImageDecoder.decodeDrawable(source)

--- a/app/src/main/java/dev/leonlatsch/photok/other/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/other/extensions/ActivityExtensions.kt
@@ -1,19 +1,3 @@
-/*
- *   Copyright 2020-2021 Leon Latsch
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 package dev.leonlatsch.photok.other.extensions
 
 import android.app.Activity


### PR DESCRIPTION
**Description:**

This raises the minSdk to 28 (Android 9).

Reasons:
- Way easier handling of media permissons (see #394 and #395 )
- <1% users on Android 7 and 8
