### PR TITLE
Fix: Only use photo picker when not using "Delete imported files"

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/ImportMenuBottomSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/ImportMenuBottomSheet.kt
@@ -90,23 +90,23 @@ private fun ImportMenuDialogContent(
     onImportChoice: (ImportChoice) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val onImportNewItems: (List<Uri>) -> Unit = {
+    val onImportNewItems: (List<Uri>) -> Unit = { urisToImport ->
         openState.value = false
 
-        if (it.isNotEmpty()) {
+        if (urisToImport.isNotEmpty()) {
             onImportChoice(
-                ImportChoice.AddNewFiles(fileUris = it)
+                ImportChoice.AddNewFiles(fileUris = urisToImport)
             )
         }
     }
 
-    val photoPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) {
-        onImportNewItems(it)
-        }
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia()
+    ) { onImportNewItems(it) }
 
-    val openDocumentLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) {
-        onImportNewItems(it)
-    }
+    val openDocumentLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments()
+    ) { onImportNewItems(it) }
 
     val restoreBackupLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportBottomSheetDialogFragment.kt
@@ -17,19 +17,12 @@
 package dev.leonlatsch.photok.gallery.ui.importing
 
 import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
-import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.model.repositories.ImportSource
-import dev.leonlatsch.photok.settings.data.Config
 import dev.leonlatsch.photok.uicomponnets.base.processdialogs.BaseProcessBottomSheetDialogFragment
-import timber.log.Timber
-import javax.inject.Inject
+
 
 /**
  * Process Fragment to import photos.
@@ -49,42 +42,11 @@ class ImportBottomSheetDialogFragment(
     true
 ) {
 
-    private val deleteRequestLauncher = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) {
-        Timber.d("Delete Request result: ${it.resultCode}")
-    }
-
-    @Inject
-    lateinit var config: Config
-
     override val viewModel: ImportViewModel by viewModels()
 
     override fun prepareViewModel(items: List<Uri>?) {
         viewModel.albumUUID = albumUUID
         viewModel.importSource = importSource
         super.prepareViewModel(items?.reversed()) // Reverse list to keep order in system gallery
-    }
-
-    override fun onProcessingDone() {
-        if (config.deleteImportedFiles && viewModel.importingFromPhotoPicker && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            requestDelete(viewModel.items)
-        }
-        super.onProcessingDone()
-    }
-
-    @RequiresApi(Build.VERSION_CODES.R)
-    private fun requestDelete(uris: List<Uri>) {
-        try {
-            // Create delete request
-            val deleteRequest = MediaStore.createDeleteRequest(
-                requireContext().contentResolver,
-                uris,
-            )
-
-            deleteRequestLauncher.launch(
-                IntentSenderRequest.Builder(deleteRequest.intentSender).build()
-            )
-        } catch (e: Exception) {
-            Timber.e("Error requesting delete: $e")
-        }
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportViewModel.kt
@@ -42,13 +42,10 @@ class ImportViewModel @Inject constructor(
     var albumUUID: String? = null
     var importSource = ImportSource.InApp
 
-    val importingFromPhotoPicker = ActivityResultContracts.PickVisualMedia.isPhotoPickerAvailable(app)
-
     override suspend fun processItem(item: Uri) {
         val photoUUID = photoRepository.safeImportPhoto(
             sourceUri = item,
             importSource = importSource,
-            uriHasDeletePermission = !importingFromPhotoPicker,
         )
         if (photoUUID.isEmpty()) {
             failuresOccurred = true

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportViewModel.kt
@@ -18,6 +18,7 @@ package dev.leonlatsch.photok.gallery.ui.importing
 
 import android.app.Application
 import android.net.Uri
+import androidx.activity.result.contract.ActivityResultContracts
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.leonlatsch.photok.gallery.albums.domain.AlbumRepository
 import dev.leonlatsch.photok.model.repositories.ImportSource
@@ -41,8 +42,14 @@ class ImportViewModel @Inject constructor(
     var albumUUID: String? = null
     var importSource = ImportSource.InApp
 
+    val importingFromPhotoPicker = ActivityResultContracts.PickVisualMedia.isPhotoPickerAvailable(app)
+
     override suspend fun processItem(item: Uri) {
-        val photoUUID = photoRepository.safeImportPhoto(item, importSource)
+        val photoUUID = photoRepository.safeImportPhoto(
+            sourceUri = item,
+            importSource = importSource,
+            uriHasDeletePermission = !importingFromPhotoPicker,
+        )
         if (photoUUID.isEmpty()) {
             failuresOccurred = true
             return

--- a/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
@@ -95,7 +95,7 @@ class PhotoRepository @Inject constructor(
      * Collects meta data and calls [safeCreatePhoto].
      * Returns re created uuid
      */
-    suspend fun safeImportPhoto(sourceUri: Uri, importSource: ImportSource, uriHasDeletePermission: Boolean): String {
+    suspend fun safeImportPhoto(sourceUri: Uri, importSource: ImportSource): String {
         val mimeType = app.contentResolver.getType(sourceUri)
         val type = PhotoType.fromMimeType(mimeType)
 
@@ -115,11 +115,7 @@ class PhotoRepository @Inject constructor(
             return String.empty
         }
 
-        if (!config.deleteImportedFiles) {
-            return photo.uuid
-        }
-
-        if (importSource == ImportSource.Share || !uriHasDeletePermission) {
+        if (!config.deleteImportedFiles || importSource == ImportSource.Share) {
             return photo.uuid
         }
 

--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
@@ -28,7 +28,6 @@ import dev.leonlatsch.photok.other.extensions.hide
 import dev.leonlatsch.photok.other.extensions.show
 import dev.leonlatsch.photok.other.extensions.vanish
 import dev.leonlatsch.photok.uicomponnets.bindings.BindableBottomSheetDialogFragment
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -83,7 +82,7 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
                     getString(processingLabelTextResource)
                 }
                 ProcessState.FINISHED -> {
-                    enterFinishedOrAbortedState()
+                    onProcessingDone()
                     setStatusIcon(R.drawable.ic_check, android.R.color.holo_green_dark)
                     // auto dismiss
                     lifecycleScope.launch {
@@ -93,7 +92,7 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
                     getString(R.string.process_finished)
                 }
                 ProcessState.ABORTED -> {
-                    enterFinishedOrAbortedState()
+                    onProcessingDone()
                     setStatusIcon(R.drawable.ic_close, android.R.color.holo_red_dark)
                     getString(R.string.process_aborted)
                 }
@@ -105,7 +104,7 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
         viewModel.runProcessing()
     }
 
-    private fun enterFinishedOrAbortedState() {
+    open fun onProcessingDone() {
         isCancelable = true
         binding.processCloseButton.show()
         binding.processAbortButton.hide()


### PR DESCRIPTION
**Description:**

The only possibility to delete the imported files is not to use the photo picker.

The photo picker does not expose the real media uri that is needed for deletion but only a syntetic uri with read only access.

Now the photo picker is used for when read only is enough. And classic open document is used when the app needs delete access.

AI Explanation:
```
In Android 13 and higher, URIs from the Photo Picker don’t map directly to MediaStore rows. They are ephemeral read-only URIs provided by the new ephemeral provider (com.android.providers.media.photopicker) and can’t be resolved to the MediaStore’s _ID column. This means that using MediaStore.createDeleteRequest on these URIs will fail with the “All requested items must be referenced by specific ID” error because the system doesn’t recognize them as MediaStore-managed content.

If you need to delete the underlying image from the device’s MediaStore, you must instead have access to the actual MediaStore content URI (the one that references a real image row). In most cases, though, the new Photo Picker is only meant to grant read access without exposing the file path or MediaStore ID.
```

> Another thing that I learned from this project

Altough:

Now its still possible to select photos and videos even when not using the photo picker. So no functionality is lost.