### PR TITLE
Bug: Fix crash with very big images

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/di/AppModule.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/di/AppModule.kt
@@ -18,6 +18,7 @@ package dev.leonlatsch.photok.di
 
 import android.content.Context
 import android.content.res.Resources
+import android.view.WindowManager
 import androidx.room.Room
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -73,6 +74,9 @@ object AppModule {
 
     @Provides
     fun provideResources(@ApplicationContext context: Context): Resources = context.resources
+
+    @Provides
+    fun provideWindowManager(@ApplicationContext context: Context) = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 
     @Provides
     fun provideGson(): Gson = GsonBuilder()

--- a/app/src/main/java/dev/leonlatsch/photok/di/AppModule.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/di/AppModule.kt
@@ -76,9 +76,6 @@ object AppModule {
     fun provideResources(@ApplicationContext context: Context): Resources = context.resources
 
     @Provides
-    fun provideWindowManager(@ApplicationContext context: Context) = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-
-    @Provides
     fun provideGson(): Gson = GsonBuilder()
         .setPrettyPrinting()
         .create()

--- a/app/src/main/java/dev/leonlatsch/photok/di/AppModule.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/di/AppModule.kt
@@ -18,7 +18,6 @@ package dev.leonlatsch.photok.di
 
 import android.content.Context
 import android.content.res.Resources
-import android.view.WindowManager
 import androidx.room.Room
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder

--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcher.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcher.kt
@@ -88,7 +88,7 @@ class EncryptedImageFetcher(
 
     private fun decodeGif(inputStream: InputStream) =
         if (Build.VERSION.SDK_INT >= VERSION_CODES.S) {
-            val bytes = inputStream.readBytes()
+            val bytes = inputStream.use { it.readBytes() }
             val source = ImageDecoder.createSource(bytes)
             ImageDecoder.decodeDrawable(source)
         } else {

--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
@@ -16,11 +16,13 @@
 
 package dev.leonlatsch.photok.imageloading.compose
 
+import android.content.Context
 import android.content.res.Resources
 import android.view.WindowManager
 import coil.ImageLoader
 import coil.fetch.Fetcher
 import coil.request.Options
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.leonlatsch.photok.imageloading.compose.model.EncryptedImageRequestData
 import dev.leonlatsch.photok.model.io.EncryptedStorageManager
 import javax.inject.Inject
@@ -29,6 +31,7 @@ class EncryptedImageFetcherFactory @Inject constructor(
     private val encryptedStorageManager: EncryptedStorageManager,
     private val resources: Resources,
     private val windowManager: WindowManager,
+    @ApplicationContext private val context: Context,
 ) : Fetcher.Factory<EncryptedImageRequestData> {
     override fun create(data: EncryptedImageRequestData, options: Options, imageLoader: ImageLoader): Fetcher =
         EncryptedImageFetcher(
@@ -36,6 +39,7 @@ class EncryptedImageFetcherFactory @Inject constructor(
             requestData = data,
             resources = resources,
             windowManager = windowManager,
+            context = context,
         )
 
 }

--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
@@ -17,6 +17,7 @@
 package dev.leonlatsch.photok.imageloading.compose
 
 import android.content.res.Resources
+import android.view.WindowManager
 import coil.ImageLoader
 import coil.fetch.Fetcher
 import coil.request.Options
@@ -27,12 +28,14 @@ import javax.inject.Inject
 class EncryptedImageFetcherFactory @Inject constructor(
     private val encryptedStorageManager: EncryptedStorageManager,
     private val resources: Resources,
+    private val windowManager: WindowManager,
 ) : Fetcher.Factory<EncryptedImageRequestData> {
     override fun create(data: EncryptedImageRequestData, options: Options, imageLoader: ImageLoader): Fetcher =
         EncryptedImageFetcher(
             encryptedStorageManager = encryptedStorageManager,
             requestData = data,
             resources = resources,
+            windowManager = windowManager,
         )
 
 }

--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/EncryptedImageFetcherFactory.kt
@@ -29,16 +29,12 @@ import javax.inject.Inject
 
 class EncryptedImageFetcherFactory @Inject constructor(
     private val encryptedStorageManager: EncryptedStorageManager,
-    private val resources: Resources,
-    private val windowManager: WindowManager,
     @ApplicationContext private val context: Context,
 ) : Fetcher.Factory<EncryptedImageRequestData> {
     override fun create(data: EncryptedImageRequestData, options: Options, imageLoader: ImageLoader): Fetcher =
         EncryptedImageFetcher(
             encryptedStorageManager = encryptedStorageManager,
             requestData = data,
-            resources = resources,
-            windowManager = windowManager,
             context = context,
         )
 

--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/di/ImageLoadingModule.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/di/ImageLoadingModule.kt
@@ -20,12 +20,14 @@ import android.content.Context
 import coil.ImageLoader
 import coil.decode.VideoFrameDecoder
 import coil.request.CachePolicy
+import coil.util.DebugLogger
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dev.leonlatsch.photok.BuildConfig
 import dev.leonlatsch.photok.imageloading.compose.EncryptedImageFetcherFactory
 import dev.leonlatsch.photok.imageloading.data.ImageStorageImpl
 import dev.leonlatsch.photok.imageloading.domain.ImageStorage
@@ -47,6 +49,11 @@ object ImageLoadingModule {
         .diskCache(null)
         .memoryCachePolicy(CachePolicy.DISABLED)
         .memoryCache(null)
+        .apply {
+            if (BuildConfig.DEBUG) {
+                logger(DebugLogger())
+            }
+        }
         .build()
 
     @Provides

--- a/app/src/main/java/dev/leonlatsch/photok/other/extensions/WindowExtensions.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/other/extensions/WindowExtensions.kt
@@ -17,11 +17,11 @@
 package dev.leonlatsch.photok.other.extensions
 
 import android.os.Build
+import android.util.DisplayMetrics
 import android.view.View
 import android.view.Window
 import android.view.WindowInsets
-import androidx.annotation.ColorRes
-import androidx.core.content.ContextCompat
+import android.view.WindowManager
 
 /**
  * Compat method for adding a [visibilityListener] to the system ui.
@@ -41,3 +41,17 @@ fun Window.addSystemUIVisibilityListener(visibilityListener: (Boolean) -> Unit) 
         }
     }
 }
+
+/**
+ * Get the device screen size. Uses appropriate API for different android versions.
+ */
+fun WindowManager.getCompatScreenSize(): Pair<Int, Int> =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val bounds = this.currentWindowMetrics.bounds
+        Pair(bounds.width(), bounds.height())
+    } else {
+        val metrics = DisplayMetrics()
+        @Suppress("DEPRECATION")
+        this.defaultDisplay.getMetrics(metrics)
+        Pair(metrics.widthPixels, metrics.heightPixels)
+    }


### PR DESCRIPTION
**Description:**

Fixes a crash when displaying very big images.

Closes #403 

Explanation:
Normal downsampling is currently not possible. Because of the nature of AES/GCM (seems like changing the IV to 12 bytes fixes this, but this is a much bigger topic)

Applied solution: Read all bytes into memory and provide as a buffered source from memory. This allows downsampling done by coil, since its already decrypted in memory.

