### PR TITLE
Feat: Themed app icon support

### DIFF
--- a/app/src/main/assets/contributors.json
+++ b/app/src/main/assets/contributors.json
@@ -52,5 +52,11 @@
     "name": "Maxim Syomochkin",
     "contact": "maksim77ster@gmail.com",
     "website": "https://mak-sim.ru"
+  },
+  {
+    "contribution": "Themed icon support",
+    "name": "sebastien46",
+    "contact": "@sebastien46 on GitHub",
+    "website": "https://github.com/sebastien46"
   }
 ]

--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
**Description:**

## This PR adds the Themed Icon feature introduced in [Android 13](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

### Examples:

- **Normal icon for reference**

  <img src="https://github.com/user-attachments/assets/307702f4-bc2e-44c5-a31a-83860a9538ea" width="20%"/>

- **Light Theme, Turquoise Palette**
   
  <img src="https://github.com/user-attachments/assets/302b519a-126e-4483-9b91-3201ada47d11" width="20%"/>

- **Dark Theme, Turquoise Palette**

  <img src="https://github.com/user-attachments/assets/bfa6f9bb-e3bc-45d8-9553-8c83033f2fa8" width="20%"/>
