### PR TITLE
Fix crash when getting file name without permission

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/other/Utils.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/other/Utils.kt
@@ -47,7 +47,7 @@ import java.io.ByteArrayInputStream
  * @since 1.0.0
  * @author Leon Latsch
  */
-fun getFileName(contentResolver: ContentResolver, uri: Uri): String? {
+fun getFileName(contentResolver: ContentResolver, uri: Uri): String? = try {
     val projection = arrayOf(MediaStore.MediaColumns.DISPLAY_NAME)
     contentResolver.query(uri, projection, null, null, null)?.use {
         if (it.moveToFirst()) {
@@ -55,7 +55,9 @@ fun getFileName(contentResolver: ContentResolver, uri: Uri): String? {
 
         }
     }
-    return null
+    null
+} catch (e: SecurityException) {
+    null
 }
 
 /**


### PR DESCRIPTION
**Description:**

Somehow the permission for getting the file name is missing for some users.

Its a small portion but also an easy fix.
