### PR TITLE
Fix: Crash when hide keyboard in setup and unlock

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/other/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/other/extensions/FragmentExtensions.kt
@@ -30,21 +30,6 @@ import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
 /**
- * Require the parent activity as a specific type to avoid casting.
- *
- * @see Fragment.requireActivity
- */
-@Suppress("UNCHECKED_CAST")
-fun <T : AppCompatActivity> Fragment.requireActivityAs(clazz: KClass<T>): T {
-    val activity = requireActivity()
-    return try {
-        activity as T
-    } catch (e: ClassCastException) {
-        throw IllegalArgumentException("$activity is not of type ${clazz.simpleName}")
-    }
-}
-
-/**
  * Extension for starting an activity for result and disable lock timer in [BaseApplication].
  */
 fun Fragment.startActivityForResultAndIgnoreTimer(intent: Intent, reqCode: Int) {

--- a/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
@@ -30,7 +30,6 @@ import dev.leonlatsch.photok.databinding.FragmentSetupBinding
 import dev.leonlatsch.photok.other.extensions.empty
 import dev.leonlatsch.photok.other.extensions.getBaseApplication
 import dev.leonlatsch.photok.other.extensions.hide
-import dev.leonlatsch.photok.other.extensions.requireActivityAs
 import dev.leonlatsch.photok.other.extensions.show
 import dev.leonlatsch.photok.other.systemBarsPadding
 import dev.leonlatsch.photok.uicomponnets.Dialogs

--- a/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
@@ -103,7 +103,7 @@ class SetupFragment : BindableFragment<FragmentSetupBinding>(R.layout.fragment_s
     }
 
     private fun finishSetup() {
-        requireActivityAs(BaseActivity::class).hideKeyboard()
+        (activity as? BaseActivity)?.hideKeyboard()
         binding.loadingOverlay.hide()
 
         if (viewModel.encryptionManager.isReady) {

--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
@@ -28,7 +28,6 @@ import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.databinding.FragmentUnlockBinding
 import dev.leonlatsch.photok.other.extensions.getBaseApplication
 import dev.leonlatsch.photok.other.extensions.hide
-import dev.leonlatsch.photok.other.extensions.requireActivityAs
 import dev.leonlatsch.photok.other.extensions.show
 import dev.leonlatsch.photok.other.extensions.vanish
 import dev.leonlatsch.photok.other.systemBarsPadding

--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
@@ -78,7 +78,7 @@ class UnlockFragment : BindableFragment<FragmentUnlockBinding>(R.layout.fragment
     }
 
     private fun unlock() {
-        requireActivityAs(BaseActivity::class).hideKeyboard()
+        (activity as? BaseActivity)?.hideKeyboard()
         binding.loadingOverlay.hide()
 
         if (viewModel.encryptionManager.isReady) {


### PR DESCRIPTION
**Description:**

Sometimes this has crashed. Since its not that important to close the keyboard, we just ignore this error by using activity instead of requireActivity
