### PR TITLE
Better error handling for restoring backups

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/backup/data/BackupRepositoryImpl.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/data/BackupRepositoryImpl.kt
@@ -99,10 +99,10 @@ class BackupRepositoryImpl @Inject constructor(
     override suspend fun writeBackupMetadata(
         backupMetaData: BackupMetaData,
         zipOutputStream: ZipOutputStream
-    ) {
+    ): Result<Unit> {
         val metaBytes = gson.toJson(backupMetaData).toByteArray()
 
-        backupLocalDataSource.writeZipEntry(
+        return backupLocalDataSource.writeZipEntry(
             BackupMetaData.FILE_NAME,
             ByteArrayInputStream(metaBytes),
             zipOutputStream,

--- a/app/src/main/java/dev/leonlatsch/photok/backup/data/BackupRepositoryImpl.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/data/BackupRepositoryImpl.kt
@@ -31,9 +31,13 @@ import timber.log.Timber
 import java.io.BufferedInputStream
 import java.io.ByteArrayInputStream
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class BackupRepositoryImpl @Inject constructor(
     private val encryptedStorageManager: EncryptedStorageManager,
@@ -127,4 +131,23 @@ class BackupRepositoryImpl @Inject constructor(
 
         return fileDetails
     }
+
+
+    override suspend fun restoreZipEntry(encryptedZipInput: InputStream, internalOutputStream: OutputStream) =
+        suspendCoroutine<Result<Unit>> { continuation ->
+            try {
+                val bytesWritten = encryptedZipInput.copyTo(internalOutputStream, bufferSize = 8192)
+                internalOutputStream.flush()
+                internalOutputStream.close()
+
+                if (bytesWritten <= 0) {
+                    continuation.resume(Result.failure(IOException("$bytesWritten bytes written from zip entry")))
+                    return@suspendCoroutine
+                }
+
+                continuation.resume(Result.success(Unit))
+            } catch (e: Exception) {
+                continuation.resume(Result.failure(e))
+            }
+        }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/BackupRepository.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/BackupRepository.kt
@@ -20,6 +20,8 @@ import android.net.Uri
 import dev.leonlatsch.photok.backup.data.BackupMetaData
 import dev.leonlatsch.photok.backup.domain.model.BackupFileDetails
 import dev.leonlatsch.photok.model.database.entity.Photo
+import java.io.InputStream
+import java.io.OutputStream
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
@@ -34,4 +36,8 @@ interface BackupRepository {
 
     suspend fun readBackupMetadata(zipInputStream: ZipInputStream, ): BackupMetaData
     suspend fun getBackupFileDetails(uri: Uri): BackupFileDetails
+    suspend fun restoreZipEntry(
+        encryptedZipInput: InputStream,
+        internalOutputStream: OutputStream
+    ): Result<Unit>
 }

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/BackupRepository.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/BackupRepository.kt
@@ -30,7 +30,8 @@ interface BackupRepository {
     suspend fun writeBackupMetadata(
         backupMetaData: BackupMetaData,
         zipOutputStream: ZipOutputStream,
-    )
+    ): Result<Unit>
+
     suspend fun readBackupMetadata(zipInputStream: ZipInputStream, ): BackupMetaData
     suspend fun getBackupFileDetails(uri: Uri): BackupFileDetails
 }

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/CreateBackupMetaFileUseCase.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/CreateBackupMetaFileUseCase.kt
@@ -25,8 +25,8 @@ class CreateBackupMetaFileUseCase @Inject constructor(
     private val backupRepository: BackupRepository,
     private val config: Config,
 ){
-    suspend operator fun invoke(zipOutputStream: ZipOutputStream) {
+    suspend operator fun invoke(zipOutputStream: ZipOutputStream): Result<Unit> {
         val dump = dumpDatabaseUseCase(config.securityPassword!!)
-        backupRepository.writeBackupMetadata(dump, zipOutputStream)
+        return backupRepository.writeBackupMetadata(dump, zipOutputStream)
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreResult.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreResult.kt
@@ -16,13 +16,6 @@
 
 package dev.leonlatsch.photok.backup.domain
 
-import dev.leonlatsch.photok.backup.data.BackupMetaData
-import java.util.zip.ZipInputStream
-
-interface RestoreBackupStrategy {
-    suspend fun restore(
-        metaData: BackupMetaData,
-        stream: ZipInputStream,
-        originalPassword: String,
-    ): RestoreResult
-}
+data class RestoreResult(
+    val errors: Int = 0,
+)

--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreBackupDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreBackupDialogFragment.kt
@@ -74,6 +74,13 @@ class RestoreBackupDialogFragment(
                     binding.restoreProgressIndicator.hide()
                     binding.restoreCloseButton.show()
                 }
+
+                RestoreState.FINISHED_WITH_ERRORS -> {
+                    viewModel.zipFileName = getString(R.string.process_finished)
+                    binding.restoreProgressIndicator.hide()
+                    binding.restoreFailuresWarning.show()
+                    binding.restoreCloseButton.show()
+                }
             }
         }
 

--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreBackupViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreBackupViewModel.kt
@@ -112,9 +112,14 @@ class RestoreBackupViewModel @Inject constructor(
         val metaData = metaData ?: error("meta.json was loaded without success")
 
         val restoreStrategy = getRestoreStrategy(backupVersion)
-        restoreStrategy.restore(metaData, zipInputStream, origPassword)
+        val result = restoreStrategy.restore(metaData, zipInputStream, origPassword)
+        zipInputStream.close()
 
-        zipInputStream.lazyClose()
-        restoreState = RestoreState.FINISHED
+        restoreState = if (result.errors > 0) {
+            RestoreState.FINISHED_WITH_ERRORS
+        } else {
+            RestoreState.FINISHED
+        }
+
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreState.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreState.kt
@@ -27,5 +27,6 @@ enum class RestoreState {
     FILE_VALID,
     FILE_INVALID,
     RESTORING,
-    FINISHED
+    FINISHED,
+    FINISHED_WITH_ERRORS,
 }

--- a/app/src/main/res/layout/dialog_restore_backup.xml
+++ b/app/src/main/res/layout/dialog_restore_backup.xml
@@ -137,6 +137,14 @@
             android:textColor="@color/darkRed"
             android:visibility="gone" />
 
+        <TextView
+            android:id="@+id/restoreFailuresWarning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/process_failures_occurred"
+            android:textColor="@color/darkYellow"
+            android:visibility="gone" />
+
         <Button
             android:id="@+id/restoreCloseButton"
             android:layout_width="wrap_content"


### PR DESCRIPTION
**Description:**

Fixes #462

Improves error handling for restoring backups and displays a generic error in the restore dialog.
Prevents app from crashing if a single file cannot be restored and skips the file instead.