### PR TITLE
New Encryption addition: Don't reuse user salt when changing password

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/model/io/EncryptedStorageManager.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/io/EncryptedStorageManager.kt
@@ -130,11 +130,11 @@ class EncryptedStorageManager @Inject constructor(
     /**
      * Re-encrypt a file with a new password.
      */
-    fun reEncryptFile(fileName: String, password: String): Boolean {
+    fun reEncryptFile(fileName: String, oldPassword: String): Boolean {
         val tmpFileName = ".tmp~$fileName"
 
-        val origInput = internalOpenEncryptedFileInput(fileName)
-        val tmpOutput = internalOpenEncryptedFileOutput(tmpFileName, password)
+        val origInput = internalOpenEncryptedFileInput(fileName, oldPassword)
+        val tmpOutput = internalOpenEncryptedFileOutput(tmpFileName)
 
         origInput ?: return false
         tmpOutput ?: return false

--- a/app/src/main/java/dev/leonlatsch/photok/security/PasswordManager.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/security/PasswordManager.kt
@@ -37,6 +37,7 @@ class PasswordManager @Inject constructor(
     fun storePassword(password: String) {
         val hashedPw = BCrypt.hashpw(password, BCrypt.gensalt())
         config.securityPassword = hashedPw
+        config.userSalt = null
     }
 
     /**

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/changepassword/ChangePasswordDialog.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/changepassword/ChangePasswordDialog.kt
@@ -102,6 +102,7 @@ class ChangePasswordDialog :
             getString(R.string.change_password_confirm_message)
         ) { _, _ ->
             ReEncryptBottomSheetDialogFragment(
+                viewModel.oldPassword,
                 viewModel.newPassword
             ).show(requireActivity().supportFragmentManager)
             dismiss()

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/changepassword/ReEncryptBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/changepassword/ReEncryptBottomSheetDialogFragment.kt
@@ -31,6 +31,7 @@ import dev.leonlatsch.photok.uicomponnets.base.processdialogs.BaseProcessBottomS
  */
 @AndroidEntryPoint
 class ReEncryptBottomSheetDialogFragment(
+    private val oldPassword: String,
     private val newPassword: String,
 ) : BaseProcessBottomSheetDialogFragment<Photo>(
     null,
@@ -42,6 +43,7 @@ class ReEncryptBottomSheetDialogFragment(
 
     override fun prepareViewModel(items: List<Photo>?) {
         super.prepareViewModel(items)
+        viewModel.oldPassword = oldPassword
         viewModel.newPassword = newPassword
     }
 }


### PR DESCRIPTION
This pr refactors the re-encryption process to utilize the new encryption key immediately after it's set, rather than waiting until all files have been processed.

It improves security even further by using a new salt for a new password

The following changes were made:
- The `oldPassword` is now passed to the `ReEncryptBottomSheetDialogFragment` and `ReEncryptViewModel`.
- In `ReEncryptViewModel`:
    - The new password is set and the `EncryptionManager` is initialized with it in `preProcess()`.
    - Key caching is enabled during `preProcess()` and disabled in `postProcess()`.
    - The `oldPassword` is now used when calling `encryptedStorageManager.reEncryptFile` to decrypt the original file.
- `EncryptedStorageManager.reEncryptFile` now accepts `oldPassword` to decrypt the existing file and uses the currently initialized key in `EncryptionManager` (which is the new key) for encrypting the temporary file.
- When storing a new password in `PasswordManager`, `config.userSalt` is now set to `null` to ensure a new salt is generated.

