### PR TITLE
Fix: Deal with dead files in migration and on app start

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/BaseApplication.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/BaseApplication.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import androidx.lifecycle.*
 import dagger.hilt.android.HiltAndroidApp
 import dev.leonlatsch.photok.main.ui.MainActivity
+import dev.leonlatsch.photok.model.repositories.CleanupDeadFilesUseCase
 import dev.leonlatsch.photok.other.setAppDesign
 import dev.leonlatsch.photok.security.EncryptionManager
 import dev.leonlatsch.photok.settings.data.Config
@@ -43,6 +44,8 @@ class BaseApplication : Application(), DefaultLifecycleObserver {
 
     @Inject
     lateinit var encryptionManager: EncryptionManager
+    @Inject
+    lateinit var cleanupDeadFilesUseCase: CleanupDeadFilesUseCase
 
     val state = MutableStateFlow(ApplicationState.LOCKED)
 
@@ -58,6 +61,7 @@ class BaseApplication : Application(), DefaultLifecycleObserver {
         }
 
         setAppDesign(config.systemDesign)
+        cleanupDeadFilesUseCase()
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/app/src/main/java/dev/leonlatsch/photok/model/repositories/CleanupDeadFilesUseCase.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/repositories/CleanupDeadFilesUseCase.kt
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2020-2024 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.model.repositories
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.leonlatsch.photok.model.database.entity.LEGACY_PHOTOK_FILE_EXTENSION
+import dev.leonlatsch.photok.model.database.entity.PHOTOK_FILE_EXTENSION
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+class CleanupDeadFilesUseCase @Inject constructor(
+    private val photoRepository: PhotoRepository,
+    @ApplicationContext private val context: Context,
+) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    operator fun invoke() {
+        scope.launch {
+            val allExisting = photoRepository.getAll()
+
+            val allFiles = context.fileList().filter {
+                it.contains(LEGACY_PHOTOK_FILE_EXTENSION) || it.contains(PHOTOK_FILE_EXTENSION)
+            }
+
+            for (file in allFiles) {
+                if (allExisting.none { file.contains(it.uuid) }) {
+                    Timber.i("Deleting dead file: $file")
+                    context.deleteFile(file)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
@@ -24,6 +24,7 @@ import dev.leonlatsch.photok.model.database.entity.Photo
 import dev.leonlatsch.photok.model.database.entity.PhotoType
 import dev.leonlatsch.photok.model.io.CreateThumbnailsUseCase
 import dev.leonlatsch.photok.model.io.EncryptedStorageManager
+import dev.leonlatsch.photok.model.io.IO
 import dev.leonlatsch.photok.other.extensions.empty
 import dev.leonlatsch.photok.other.extensions.lazyClose
 import dev.leonlatsch.photok.other.getFileName
@@ -50,6 +51,7 @@ class PhotoRepository @Inject constructor(
     private val createThumbnail: CreateThumbnailsUseCase,
     private val app: Application,
     private val config: Config,
+    private val io: IO,
 ) {
 
     // region DATABASE
@@ -148,6 +150,10 @@ class PhotoRepository @Inject constructor(
 
             val photoId = insert(photo)
             success = photoId != -1L
+        }
+
+        if (!success) {
+            deleteInternalPhotoData(photo)
         }
 
         return success

--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
@@ -18,6 +18,8 @@ package dev.leonlatsch.photok.uicomponnets.base.processdialogs
 
 import android.os.Bundle
 import android.view.View
+import android.view.Window
+import android.view.WindowManager
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
@@ -62,6 +64,8 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
 
         viewModel.processState = ProcessState.INITIALIZE
 
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
         viewModel.addOnPropertyChange<ProcessState>(BR.processState) {
             val label: String = when (it) {
                 ProcessState.INITIALIZE -> {
@@ -105,6 +109,8 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
     }
 
     open fun onProcessingDone() {
+        activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
         isCancelable = true
         binding.processCloseButton.show()
         binding.processAbortButton.hide()


### PR DESCRIPTION
Fixes dead files being left over when an import fails.

- Prevent these files
- Cleans them up on app start
- Double checks in migration to not try to process them