### PR TITLE
Fix: Video thumbnail and album cover for videos

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/gallery/albums/Mappers.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/albums/Mappers.kt
@@ -49,8 +49,13 @@ fun Album.toUi(): AlbumItem = AlbumItem(
     name = name,
     itemCount = files.size,
     albumCover = files.firstOrNull()?.let { firstPhoto ->
+        val albumCoverFileName = if (firstPhoto.type.isVideo) {
+            firstPhoto.internalVideoPreviewFileName
+        } else {
+            firstPhoto.internalFileName
+        }
         AlbumCover(
-            filename = firstPhoto.internalFileName,
+            filename = albumCoverFileName,
             mimeType = firstPhoto.type.mimeType
         )
     }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
@@ -283,7 +283,7 @@ fun PhotoGrid(
 
 private val VideoIconSize = 20.dp
 private val SelectedPadding = 15.dp
-private val CheckmarkPadding = SelectedPadding - 7.dp
+private val CheckmarkPadding = SelectedPadding - 9.dp
 
 @Composable
 fun Modifier.multiSelectionItem(selected: Boolean): Modifier {
@@ -372,7 +372,6 @@ private fun GalleryPhotoTile(
                     .padding(CheckmarkPadding)
                     .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.background)
-                    .size(VideoIconSize)
                     .align(Alignment.TopStart)
             )
         }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
@@ -326,7 +326,7 @@ private fun GalleryPhotoTile(
 
         if (LocalInspectionMode.current) {
             Box(
-                modifier = contentModifier.background(Color.LightGray)
+                modifier = contentModifier.background(Color.DarkGray)
             )
         } else {
             val requestData = remember(photoTile) {
@@ -343,15 +343,19 @@ private fun GalleryPhotoTile(
             )
         }
 
-        AnimatedVisibility(photoTile.type.isVideo && !selected) {
+        AnimatedVisibility(
+            visible = photoTile.type.isVideo && !selected,
+            enter = scaleIn(),
+            exit = scaleOut(),
+            modifier = Modifier
+                .padding(2.dp)
+                .size(VideoIconSize)
+                .align(Alignment.BottomStart)
+        ) {
             Icon(
                 painter = painterResource(R.drawable.ic_videocam),
                 contentDescription = null,
                 tint = Color.LightGray,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .size(VideoIconSize)
-                    .align(Alignment.BottomStart)
             )
         }
 


### PR DESCRIPTION
This commit fixes two issues related to videos:
- Album covers now correctly display video thumbnails instead of a blank image.
- The video indicator icon in the gallery now has an animation and its preview background color in Compose previews is changed to DarkGray.
