### PR TITLE
Fix: Simplify back press handling to finish activity

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/GalleryFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/GalleryFragment.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
@@ -27,12 +28,14 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import coil.ImageLoader
 import dagger.hilt.android.AndroidEntryPoint
+import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.gallery.ui.components.AlbumPickerViewModel
 import dev.leonlatsch.photok.gallery.ui.compose.GalleryScreen
 import dev.leonlatsch.photok.gallery.ui.navigation.GalleryNavigator
 import dev.leonlatsch.photok.gallery.ui.navigation.PhotoActionsNavigator
 import dev.leonlatsch.photok.imageloading.compose.LocalEncryptedImageLoader
 import dev.leonlatsch.photok.imageloading.di.EncryptedImageLoader
+import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
 import dev.leonlatsch.photok.other.extensions.launchLifecycleAwareJob
 import dev.leonlatsch.photok.settings.data.Config
 import dev.leonlatsch.photok.settings.ui.compose.LocalConfig
@@ -74,6 +77,7 @@ class GalleryFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        finishOnBackWhileStarted()
 
         launchLifecycleAwareJob {
             viewModel.eventsFlow.collect { event ->
@@ -88,5 +92,6 @@ class GalleryFragment : Fragment() {
         }
 
         viewModel.checkForNewFeatures()
+
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/main/ui/MainActivity.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/main/ui/MainActivity.kt
@@ -103,13 +103,6 @@ class MainActivity : BindableActivity<ActivityMainBinding>(R.layout.activity_mai
                 viewModel.onDestinationChanged(destination.id)
             }
 
-            onBackPressedDispatcher.addCallback {
-                if (navController.currentDestination?.id == R.id.galleryFragment) {
-                    finish()
-                } else {
-                    navController.navigateUp()
-                }
-            }
         }
     }
 

--- a/app/src/main/java/dev/leonlatsch/photok/onboarding/ui/OnBoardingFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/onboarding/ui/OnBoardingFragment.kt
@@ -24,6 +24,7 @@ import androidx.viewpager.widget.ViewPager
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.databinding.FragmentOnboardingBinding
+import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
 import dev.leonlatsch.photok.other.systemBarsPadding
 import dev.leonlatsch.photok.settings.data.Config
 import dev.leonlatsch.photok.uicomponnets.ViewPagerAdapter
@@ -49,6 +50,7 @@ class OnBoardingFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.systemBarsPadding()
+        finishOnBackWhileStarted()
 
         binding.onBoardingDotSelector1.isSelected = true
         binding.onBoardingDotSelector2.isSelected = false

--- a/app/src/main/java/dev/leonlatsch/photok/other/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/other/extensions/FragmentExtensions.kt
@@ -16,6 +16,7 @@
 
 package dev.leonlatsch.photok.other.extensions
 
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
@@ -45,4 +46,10 @@ inline fun <FactoryType, reified ViewModelType : ViewModel> Fragment.assistedVie
             viewModelProducer(factory)
         }
     )[ViewModelType::class.java]
+}
+
+fun Fragment.finishOnBackWhileStarted() {
+    activity?.onBackPressedDispatcher?.addCallback(viewLifecycleOwner) {
+        activity?.finish()
+    }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
@@ -28,6 +28,7 @@ import dev.leonlatsch.photok.BuildConfig
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.databinding.FragmentSetupBinding
 import dev.leonlatsch.photok.other.extensions.empty
+import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
 import dev.leonlatsch.photok.other.extensions.getBaseApplication
 import dev.leonlatsch.photok.other.extensions.hide
 import dev.leonlatsch.photok.other.extensions.show
@@ -50,6 +51,7 @@ class SetupFragment : BindableFragment<FragmentSetupBinding>(R.layout.fragment_s
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         view.systemBarsPadding()
+        finishOnBackWhileStarted()
 
         if (BuildConfig.DEBUG) {
             viewModel.password = "abc123"

--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
@@ -27,6 +27,7 @@ import dev.leonlatsch.photok.BR
 import dev.leonlatsch.photok.BuildConfig
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.databinding.FragmentUnlockBinding
+import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
 import dev.leonlatsch.photok.other.extensions.getBaseApplication
 import dev.leonlatsch.photok.other.extensions.hide
 import dev.leonlatsch.photok.other.extensions.launchLifecycleAwareJob
@@ -69,6 +70,7 @@ class UnlockFragment : BindableFragment<FragmentUnlockBinding>(R.layout.fragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         view.systemBarsPadding()
+        finishOnBackWhileStarted()
 
         if (BuildConfig.DEBUG) {
             viewModel.password = "abc123"


### PR DESCRIPTION
This commit introduces a new Fragment extension function `finishOnBackWhileStarted` which simplifies the back press handling to finish the current activity when the fragment is started.

This extension is now used in:
- `SetupFragment`
- `OnBoardingFragment`
- `GalleryFragment`
- `UnlockFragment`

The custom back press handling in `MainActivity` has been removed as it's no longer needed.

Fixes #508 

