### PR TITLE
Fix: FAB visibility in gallery

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
@@ -96,11 +96,6 @@ fun PhotoGallery(
 ) {
     val activity = LocalActivity.current
     val importMenuBottomSheetVisible = remember { mutableStateOf(false) }
-    val magicFabVisible = remember {
-        derivedStateOf {
-            multiSelectionState.isActive.value.not()
-        }
-    }
 
     // Hide magic fab menu when multi selection active
     LaunchedEffect(multiSelectionState.isActive.value) {
@@ -117,7 +112,7 @@ fun PhotoGallery(
         )
 
         AnimatedVisibility(
-            visible = magicFabVisible.value,
+            visible = multiSelectionState.isActive.value.not(),
             enter = slideInVertically { it },
             exit = slideOutVertically { it },
             modifier = Modifier


### PR DESCRIPTION
Removes the unnecessary `magicFabVisible` derived state in the `PhotoGallery` composable. The visibility of the Floating Action Button is now directly determined by `multiSelectionState.isActive.value.not()`
