### PR TITLE
Feature: Add haptic feedback for multi-selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <queries>
         <intent>

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/components/PhotoGallery.kt
@@ -53,7 +53,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -62,7 +61,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -245,6 +246,8 @@ private fun PhotoGrid(
         else -> PORTRAIT_COLUMN_COUNT
     }
 
+    val haptic = LocalHapticFeedback.current
+
     LazyVerticalGrid(
         columns = GridCells.Fixed(columnCount),
         modifier = modifier.fillMaxWidth(),
@@ -265,11 +268,14 @@ private fun PhotoGrid(
                     } else {
                         multiSelectionState.selectItem(it.uuid)
                     }
+                    
+                    haptic.performHapticFeedback(HapticFeedbackType.ContextClick)
                 },
                 selected = multiSelectionState.selectedItems.value.contains(it.uuid),
                 onLongPress = {
                     if (multiSelectionState.isActive.value.not()) {
                         multiSelectionState.selectItem(it.uuid)
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     }
                 },
                 modifier = Modifier.animateItem(),


### PR DESCRIPTION
Adds haptic feedback to the photo gallery for multi-selection actions to improve user experience.

- A long press to initiate multi-select mode now triggers a vibration.
- Tapping to select or deselect items in multi-select mode also provides haptic feedback.
- Adds the `VIBRATE` permission to `AndroidManifest.xml` to enable this functionality.
