### PR TITLE
fix: Prevent crash on process dialog auto-dismiss

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
@@ -90,7 +90,7 @@ abstract class BaseProcessBottomSheetDialogFragment<T>(
                     // auto dismiss
                     lifecycleScope.launch {
                         delay(1500)
-                        dismiss()
+                        runCatching { dismiss() } // May throw if already dismissed by user
                     }
                     getString(R.string.process_finished)
                 }


### PR DESCRIPTION
Wrap the `dismiss()` call in a `runCatching` block to prevent a crash that could occur if the user manually dismisses the dialog before the automatic dismissal is triggered.
