### PR TITLE
Feature: Add setting to configure gallery start page

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/gallery/albums/ui/AlbumsFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/albums/ui/AlbumsFragment.kt
@@ -31,7 +31,10 @@ import dev.leonlatsch.photok.gallery.albums.ui.compose.AlbumsScreen
 import dev.leonlatsch.photok.gallery.albums.ui.navigation.AlbumsNavigator
 import dev.leonlatsch.photok.imageloading.compose.LocalEncryptedImageLoader
 import dev.leonlatsch.photok.imageloading.di.EncryptedImageLoader
+import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
 import dev.leonlatsch.photok.other.extensions.launchLifecycleAwareJob
+import dev.leonlatsch.photok.settings.data.Config
+import dev.leonlatsch.photok.settings.data.StartPage
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -45,6 +48,9 @@ class AlbumsFragment : Fragment() {
     @EncryptedImageLoader
     @Inject
     lateinit var encryptedImageLoader: ImageLoader
+
+    @Inject
+    lateinit var config: Config
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -62,6 +68,10 @@ class AlbumsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        finishOnBackWhileStarted(
+            enabled = config.galleryStartPage == StartPage.Albums,
+        )
 
         launchLifecycleAwareJob {
             viewModel.navEvent.collect { event ->

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/GalleryFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/GalleryFragment.kt
@@ -36,6 +36,7 @@ import dev.leonlatsch.photok.imageloading.di.EncryptedImageLoader
 import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
 import dev.leonlatsch.photok.other.extensions.launchLifecycleAwareJob
 import dev.leonlatsch.photok.settings.data.Config
+import dev.leonlatsch.photok.settings.data.StartPage
 import dev.leonlatsch.photok.settings.ui.compose.LocalConfig
 import javax.inject.Inject
 
@@ -75,7 +76,9 @@ class GalleryFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        finishOnBackWhileStarted()
+        finishOnBackWhileStarted(
+            enabled = config.galleryStartPage == StartPage.AllFiles,
+        )
 
         launchLifecycleAwareJob {
             viewModel.eventsFlow.collect { event ->

--- a/app/src/main/java/dev/leonlatsch/photok/other/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/other/extensions/FragmentExtensions.kt
@@ -48,8 +48,11 @@ inline fun <FactoryType, reified ViewModelType : ViewModel> Fragment.assistedVie
     )[ViewModelType::class.java]
 }
 
-fun Fragment.finishOnBackWhileStarted() {
-    activity?.onBackPressedDispatcher?.addCallback(viewLifecycleOwner) {
+fun Fragment.finishOnBackWhileStarted(enabled: Boolean = true) {
+    activity?.onBackPressedDispatcher?.addCallback(
+        owner = viewLifecycleOwner,
+        enabled = enabled,
+    ) {
         activity?.finish()
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/data/Config.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/data/Config.kt
@@ -59,6 +59,13 @@ class Config(context: Context) {
         set(value) = putBoolean(GALLERY_AUTO_FULLSCREEN, value)
 
     /**
+     * Determines the start page of the gallery.
+     */
+    var galleryStartPage: StartPage
+        get() = StartPage.fromValue(getString("gallery^startPage", StartPage.AllFiles.value))
+        set(value) = putString("gallery^startPage", value.value)
+
+    /**
      * Determines if screenshots should be allowed.
      */
     var securityAllowScreenshots: Boolean

--- a/app/src/main/java/dev/leonlatsch/photok/settings/data/StartPage.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/data/StartPage.kt
@@ -1,0 +1,28 @@
+/*
+ *   Copyright 2020-2024 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.settings.data
+
+enum class StartPage(val value: String) {
+    AllFiles("all_files"),
+    Albums("albums");
+
+    companion object {
+        fun fromValue(value: String?): StartPage {
+            return entries.find { it.value == value } ?: AllFiles
+        }
+    }
+}

--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
@@ -38,6 +38,7 @@ import dev.leonlatsch.photok.security.biometric.BiometricUnlock
 import dev.leonlatsch.photok.security.biometric.UserCanceledBiometricsException
 import dev.leonlatsch.photok.security.migration.LegacyEncryptionMigrator
 import dev.leonlatsch.photok.settings.data.Config
+import dev.leonlatsch.photok.settings.data.StartPage
 import dev.leonlatsch.photok.uicomponnets.Dialogs
 import dev.leonlatsch.photok.uicomponnets.base.BaseActivity
 import dev.leonlatsch.photok.uicomponnets.bindings.BindableFragment
@@ -144,7 +145,12 @@ class UnlockFragment : BindableFragment<FragmentUnlockBinding>(R.layout.fragment
                 findNavController().navigate(R.id.action_unlockFragment_to_encryptionMigrationFragment)
             }
         } else {
-            findNavController().navigate(R.id.action_unlockFragment_to_galleryFragment)
+            val startPageDest = when (config.galleryStartPage) {
+                StartPage.AllFiles -> R.id.action_unlockFragment_to_galleryFragment
+                StartPage.Albums -> R.id.action_unlockFragment_to_albumsFragment
+            }
+
+            findNavController().navigate(startPageDest)
         }
     }
 

--- a/app/src/main/res/drawable/ic_gallery_thumbnail.xml
+++ b/app/src/main/res/drawable/ic_gallery_thumbnail.xml
@@ -1,0 +1,26 @@
+<!--
+  ~   Copyright 2020-2024 Leon Latsch
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M120,760q-33,0 -56.5,-23.5T40,680v-400q0,-33 23.5,-56.5T120,200h400q33,0 56.5,23.5T600,280v400q0,33 -23.5,56.5T520,760L120,760ZM720,440q-17,0 -28.5,-11.5T680,400v-160q0,-17 11.5,-28.5T720,200h160q17,0 28.5,11.5T920,240v160q0,17 -11.5,28.5T880,440L720,440ZM760,360h80v-80h-80v80ZM120,680h400v-400L120,280v400ZM160,600h320L375,460l-75,100 -55,-73 -85,113ZM720,760q-17,0 -28.5,-11.5T680,720v-160q0,-17 11.5,-28.5T720,520h160q17,0 28.5,11.5T920,560v160q0,17 -11.5,28.5T880,760L720,760ZM760,680h80v-80h-80v80ZM120,680v-400,400ZM760,360v-80,80ZM760,680v-80,80Z"
+      android:fillColor="@android:color/white"/>
+</vector>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -79,6 +79,13 @@
             app:destination="@id/encryptionMigrationFragment"
             app:popUpTo="@id/unlockFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_unlockFragment_to_albumsFragment"
+            app:destination="@id/albumsFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/slide_to_bottom"
+            app:popUpTo="@id/unlockFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/onBoardingFragment"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -148,6 +148,7 @@
     <string name="settings_category_gallery">المعرض</string>
     <string name="settings_gallery_auto_fullscreen_title">ملء الشاشة تلقائيًا</string>
     <string name="settings_gallery_auto_fullscreen_summary">أدخل وضع ملء الشاشة عند فتح ملف</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">حماية</string>
     <string name="settings_security_allow_screenshots_title">السماح بلقطات الشاشة</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -150,6 +150,7 @@
     <string name="settings_category_gallery">Galerie</string>
     <string name="settings_gallery_auto_fullscreen_title">Auto Vollbild</string>
     <string name="settings_gallery_auto_fullscreen_summary">Vollbild Modus beim öffnen einer Datei</string>
+    <string name="settings_gallery_start_page_title">Startseite</string>
 
     <string name="settings_category_security">Sicherheit</string>
     <string name="settings_security_allow_screenshots_title">Erlaube Screenshots</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -150,6 +150,7 @@
     <string name="settings_category_gallery">Galería</string>
     <string name="settings_gallery_auto_fullscreen_title">Pantalla completa automática</string>
     <string name="settings_gallery_auto_fullscreen_summary">Ingresar al modo de pantalla completa al abrir una foto</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Seguridad</string>
     <string name="settings_security_allow_screenshots_title">Permitir capturas de pantalla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -150,6 +150,7 @@
     <string name="settings_category_gallery">Galerie</string>
     <string name="settings_gallery_auto_fullscreen_title">Plein écran automatique</string>
     <string name="settings_gallery_auto_fullscreen_summary">Entrer en mode plein écran lors de l\'ouverture d\'un fichier</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Sécurité</string>
     <string name="settings_security_allow_screenshots_title">Autoriser les captures d\'écran</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -148,6 +148,7 @@
     <string name="settings_category_gallery">Galleria</string>
     <string name="settings_gallery_auto_fullscreen_title">Schermo intero automatico</string>
     <string name="settings_gallery_auto_fullscreen_summary">Entra in modalità a schermo intero quando apri un file</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Sicurezza</string>
     <string name="settings_security_allow_screenshots_title">Consenti screenshot</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -131,6 +131,7 @@
     <string name="settings_category_gallery">Galerij</string>
     <string name="settings_gallery_auto_fullscreen_title">Automatisch volledig scherm</string>
     <string name="settings_gallery_auto_fullscreen_summary">Open volledig scherm modus bij het openen van een bestand</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Veiligheid</string>
     <string name="settings_security_allow_screenshots_title">Screenshots toestaan</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -149,6 +149,7 @@
     <string name="settings_category_gallery">Galeria</string>
     <string name="settings_gallery_auto_fullscreen_title">Auto tela completa</string>
     <string name="settings_gallery_auto_fullscreen_summary">Entrar no modo de tela completa ao abrir um arquivo</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Segurança</string>
     <string name="settings_security_allow_screenshots_title">Permitir as capturas da tela</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -148,6 +148,7 @@
     <string name="settings_category_gallery">Галерея</string>
     <string name="settings_gallery_auto_fullscreen_title">Автоматический полный экран</string>
     <string name="settings_gallery_auto_fullscreen_summary">Входить в полноэкранный режим при открытии файла</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Безопасность</string>
     <string name="settings_security_allow_screenshots_title">Разрешить скриншоты</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -131,6 +131,7 @@
     <string name="settings_category_gallery">Galeri</string>
     <string name="settings_gallery_auto_fullscreen_title">Otomatik Tam Ekran</string>
     <string name="settings_gallery_auto_fullscreen_summary">Bir dosya açıldığında tam ekran moduna geç</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">Güvenlik</string>
     <string name="settings_security_allow_screenshots_title">Ekran Görüntülerine İzin Ver</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -148,6 +148,7 @@
     <string name="settings_category_gallery">图库</string>
     <string name="settings_gallery_auto_fullscreen_title">自动全屏</string>
     <string name="settings_gallery_auto_fullscreen_summary">打开文件时进入全屏模式</string>
+    <string name="settings_gallery_start_page_title">Start Page</string> <!-- TODO -->
 
     <string name="settings_category_security">安全</string>
     <string name="settings_security_allow_screenshots_title">允许截屏</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -58,4 +58,13 @@
         <item>@string/news_summary_3</item>
         <!--<item>@string/news_summary_4</item>-->
     </string-array>
+
+    <string-array name="startPageStrings">
+        <item>@string/gallery_all_photos_label</item>
+        <item>@string/gallery_albums_label</item>
+    </string-array>
+    <string-array name="startPage">
+        <item>all_files</item>
+        <item>albums</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="settings_category_gallery">Gallery</string>
     <string name="settings_gallery_auto_fullscreen_title">Auto Fullscreen</string>
     <string name="settings_gallery_auto_fullscreen_summary">Enter fullscreen mode when opening a file</string>
+    <string name="settings_gallery_start_page_title">Start Page</string>
 
     <string name="settings_category_security">Security</string>
     <string name="settings_security_allow_screenshots_title">Allow Screenshots</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -36,6 +36,14 @@
             android:key="gallery^fullscreen.auto"
             android:summary="@string/settings_gallery_auto_fullscreen_summary"
             android:title="@string/settings_gallery_auto_fullscreen_title" />
+        <ListPreference
+            android:defaultValue="all_files"
+            android:entries="@array/startPageStrings"
+            android:entryValues="@array/startPage"
+            android:icon="@drawable/ic_gallery_thumbnail"
+            android:key="gallery^startPage"
+            android:title="@string/settings_gallery_start_page_title"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_security">


### PR DESCRIPTION
This introduces a new gallery setting that allows users to select the initial view when opening the app. The options are "All Files" or "Albums".

- Adds a `StartPage` enum and a `galleryStartPage` property to the `Config`.
- Implements a `ListPreference` in the settings screen for this option.
- Updates the `UnlockFragment` to navigate to the configured start page after a successful unlock.
- Adjusts the back-button behavior on `GalleryFragment` and `AlbumsFragment` to correctly exit the app based on the selected start page.
- Adds new string resources for the setting and its options, with German being translated and others marked as TODO.
- Includes a new drawable icon (`ic_gallery_thumbnail`) for the setting.
