### PR TITLE
Fix: Wrong file order when importing backup

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/backup/data/BackupMetaData.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/data/BackupMetaData.kt
@@ -46,6 +46,12 @@ data class BackupMetaData(
     }
 }
 
+fun BackupMetaData.getPhotosInOriginalOrder(): List<PhotoBackup> {
+    return photos.sortedBy {
+        it.importedAt
+    } // ASC to keep original order. Dump is created with DESC
+}
+
 data class PhotoBackup(
     val fileName: String,
     val importedAt: Long,

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/DumpDatabaseUseCase.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/DumpDatabaseUseCase.kt
@@ -20,11 +20,9 @@ import dev.leonlatsch.photok.backup.data.BackupMetaData
 import dev.leonlatsch.photok.backup.data.toBackup
 import dev.leonlatsch.photok.gallery.albums.domain.AlbumRepository
 import dev.leonlatsch.photok.model.repositories.PhotoRepository
-import dev.leonlatsch.photok.security.GetOrCreateUserSaltUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import kotlin.io.encoding.Base64
 
 /**
  * Creates a [BackupMetaData] from the current database
@@ -34,7 +32,7 @@ class DumpDatabaseUseCase @Inject constructor(
     private val albumRepository: AlbumRepository,
 ) {
     suspend operator fun invoke(password: String, version: Int): BackupMetaData = withContext(Dispatchers.IO) {
-        val photos = photoRepository.getAll().map { it.toBackup() }
+        val photos = photoRepository.findAllPhotosByImportDateDesc().map { it.toBackup() }
         val albums = albumRepository.getAlbums().map { it.toBackup() }
         val albumPhotoLinks = albumRepository.getAllAlbumPhotoLinks().map { it.toBackup() }
 

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreBackupV2.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreBackupV2.kt
@@ -17,6 +17,7 @@
 package dev.leonlatsch.photok.backup.domain
 
 import dev.leonlatsch.photok.backup.data.BackupMetaData
+import dev.leonlatsch.photok.backup.data.getPhotosInOriginalOrder
 import dev.leonlatsch.photok.backup.data.toDomain
 import dev.leonlatsch.photok.model.database.entity.LEGACY_PHOTOK_FILE_EXTENSION
 import dev.leonlatsch.photok.model.database.entity.PHOTOK_FILE_EXTENSION
@@ -112,7 +113,7 @@ class RestoreBackupV2 @Inject constructor(
             ze = stream.nextEntry
         }
 
-        metaData.photos.forEach { photoBackup ->
+        metaData.getPhotosInOriginalOrder().forEach { photoBackup ->
             val newPhoto = photoBackup
                 .toDomain()
                 .copy(importedAt = System.currentTimeMillis())

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreBackupV3.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreBackupV3.kt
@@ -17,6 +17,7 @@
 package dev.leonlatsch.photok.backup.domain
 
 import dev.leonlatsch.photok.backup.data.BackupMetaData
+import dev.leonlatsch.photok.backup.data.getPhotosInOriginalOrder
 import dev.leonlatsch.photok.backup.data.toDomain
 import dev.leonlatsch.photok.gallery.albums.domain.AlbumRepository
 import dev.leonlatsch.photok.model.database.entity.LEGACY_PHOTOK_FILE_EXTENSION
@@ -117,7 +118,7 @@ class RestoreBackupV3 @Inject constructor(
             ze = stream.nextEntry
         }
 
-        metaData.photos.forEach { photoBackup ->
+        metaData.getPhotosInOriginalOrder().forEach { photoBackup ->
             val newPhoto = photoBackup
                 .toDomain()
                 .copy(importedAt = System.currentTimeMillis())

--- a/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreBackupV4.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/domain/RestoreBackupV4.kt
@@ -17,6 +17,7 @@
 package dev.leonlatsch.photok.backup.domain
 
 import dev.leonlatsch.photok.backup.data.BackupMetaData
+import dev.leonlatsch.photok.backup.data.getPhotosInOriginalOrder
 import dev.leonlatsch.photok.backup.data.toDomain
 import dev.leonlatsch.photok.gallery.albums.domain.AlbumRepository
 import dev.leonlatsch.photok.model.io.EncryptedStorageManager
@@ -120,7 +121,7 @@ class RestoreBackupV4 @Inject constructor(
 
         encryptionManager.keyCacheEnabled = false
 
-        metaData.photos.forEach { photoBackup ->
+        metaData.getPhotosInOriginalOrder().forEach { photoBackup ->
             val newPhoto = photoBackup
                 .toDomain()
                 .copy(importedAt = System.currentTimeMillis())

--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/BackupViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/BackupViewModel.kt
@@ -64,7 +64,7 @@ class BackupViewModel @Inject constructor(
     private lateinit var zipOutputStream: ZipOutputStream
 
     override suspend fun preProcess() {
-        items = photoRepository.getAll()
+        items = photoRepository.findAllPhotosByImportDateDesc()
         elementsToProcess = items.size
         zipOutputStream = io.zip.openZipOutput(uri)
         strategy.preBackup()

--- a/app/src/main/java/dev/leonlatsch/photok/imageviewer/ui/ImageViewerViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageviewer/ui/ImageViewerViewModel.kt
@@ -67,7 +67,7 @@ class ImageViewerViewModel @Inject constructor(
         }
 
         photos = if (albumUUID.isEmpty()) {
-            photoRepository.getAll()
+            photoRepository.findAllPhotosByImportDateDesc()
         } else {
             albumRepository.getPhotosForAlbum(albumUUID)
         }

--- a/app/src/main/java/dev/leonlatsch/photok/model/database/dao/PhotoDao.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/database/dao/PhotoDao.kt
@@ -70,7 +70,7 @@ interface PhotoDao {
      * @return all photos as [List]
      */
     @Query("SELECT * FROM photo ORDER BY importedAt DESC")
-    suspend fun getAll(): List<Photo>
+    suspend fun findAllPhotosByImportDateDesc(): List<Photo>
 
     @Query("SELECT * FROM photo ORDER BY importedAt DESC")
     fun observeAll(): Flow<List<Photo>>

--- a/app/src/main/java/dev/leonlatsch/photok/model/repositories/CleanupDeadFilesUseCase.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/repositories/CleanupDeadFilesUseCase.kt
@@ -21,7 +21,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.leonlatsch.photok.model.database.entity.LEGACY_PHOTOK_FILE_EXTENSION
 import dev.leonlatsch.photok.model.database.entity.PHOTOK_FILE_EXTENSION
 import dev.leonlatsch.photok.model.io.EncryptedStorageManager
-import dev.leonlatsch.photok.other.extensions.remove
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -37,7 +36,7 @@ class CleanupDeadFilesUseCase @Inject constructor(
 
     operator fun invoke() {
         scope.launch {
-            val allExisting = photoRepository.getAll()
+            val allExisting = photoRepository.findAllPhotosByImportDateDesc()
 
             val allFiles = context.fileList().filter {
                 it.contains(LEGACY_PHOTOK_FILE_EXTENSION) || it.contains(PHOTOK_FILE_EXTENSION)

--- a/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
@@ -73,9 +73,9 @@ class PhotoRepository @Inject constructor(
     suspend fun get(uuid: String) = photoDao.get(uuid)
 
     /**
-     * @see PhotoDao.getAll
+     * @see PhotoDao.findAllPhotosByImportDateDesc
      */
-    suspend fun getAll() = photoDao.getAll()
+    suspend fun findAllPhotosByImportDateDesc() = photoDao.findAllPhotosByImportDateDesc()
 
     fun observeAll(sort: Sort) = photoDao.observeAllSorted(sort)
 

--- a/app/src/main/java/dev/leonlatsch/photok/security/migration/LegacyEncryptionMigrator.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/security/migration/LegacyEncryptionMigrator.kt
@@ -30,8 +30,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
-import java.security.GeneralSecurityException
-import java.security.SecureRandom
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -80,7 +78,7 @@ class LegacyEncryptionMigrator @Inject constructor(
 
         try {
 
-            val allPhotos = photoRepository.getAll()
+            val allPhotos = photoRepository.findAllPhotosByImportDateDesc()
 
             val legacyFiles = app.fileList().filter { legacyFile ->
                 legacyFile.contains(LEGACY_PHOTOK_FILE_EXTENSION) // Is .photok file

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/SettingsViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/SettingsViewModel.kt
@@ -45,7 +45,7 @@ class SettingsViewModel @Inject constructor(
      * Reset all components and call [BaseApplication.lockApp]
      */
     fun resetComponents() = viewModelScope.launch {
-        val allPhotos = photoRepository.getAll()
+        val allPhotos = photoRepository.findAllPhotosByImportDateDesc()
         for (photo in allPhotos) {
             photoRepository.deleteInternalPhotoData(photo)
         }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/changepassword/ReEncryptViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/changepassword/ReEncryptViewModel.kt
@@ -46,7 +46,7 @@ class ReEncryptViewModel @Inject constructor(
     lateinit var newPassword: String
 
     override suspend fun preProcess() {
-        items = photoRepository.getAll()
+        items = photoRepository.findAllPhotosByImportDateDesc()
         elementsToProcess = items.size
 
         passwordManager.storePassword(newPassword)


### PR DESCRIPTION
This fixes the order of files when importing a backup. It recreates the
original order before assigning new import timestamps.

In a future rewrite of the restore backup UI it should be possible to
configure if the original timestamp should be kept.

Additionally this PR changes the restoring of V1 backups to also first
process to files and then insert all database items.

Fixes: #380
