### PR TITLE
Fix: Improve image viewer performance when swiping

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/imageviewer/ui/ImageViewerFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageviewer/ui/ImageViewerFragment.kt
@@ -85,6 +85,7 @@ class ImageViewerFragment :
 
         initializeSystemUI()
 
+        binding.viewPhotoViewPager.offscreenPageLimit = 1
         binding.viewPhotoViewPager.registerOnPageChangeCallback(object :
             ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {


### PR DESCRIPTION
Set the `offscreenPageLimit` of `viewPhotoViewPager` to 1 in `ImageViewerFragment.kt`. This ensures that the adjacent page is preloaded, improving the swipe performance and smoothness when viewing images.
