### PR TITLE
Feature: Add support for WebP images

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/model/EncryptedImageRequestData.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageloading/compose/model/EncryptedImageRequestData.kt
@@ -19,5 +19,5 @@ package dev.leonlatsch.photok.imageloading.compose.model
 data class EncryptedImageRequestData(
     val internalFileName: String,
     val mimeType: String,
-    val playGif: Boolean = false,
+    val playAnimation: Boolean = false,
 )

--- a/app/src/main/java/dev/leonlatsch/photok/imageviewer/ui/compose/PhotoViewHolderContent.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/imageviewer/ui/compose/PhotoViewHolderContent.kt
@@ -64,7 +64,7 @@ fun PhotoViewHolderContent(
                 EncryptedImageRequestData(
                     internalFileName = fileName,
                     mimeType = photo.type.mimeType,
-                    playGif = true,
+                    playAnimation = true,
                 )
             }
 

--- a/app/src/main/java/dev/leonlatsch/photok/model/database/entity/PhotoType.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/database/entity/PhotoType.kt
@@ -36,7 +36,8 @@ enum class PhotoType(
     MP4(4, "video/mp4"),
     MPEG(5, "video/mpeg"),
     WEBM(6, "video/webm"),
-    MOV(7, "video/quicktime");
+    MOV(7, "video/quicktime"),
+    WEBP(8, "image/webp");
 
     val isVideo: Boolean
         get() = when (value) {
@@ -62,6 +63,7 @@ enum class PhotoType(
             MPEG.mimeType -> MPEG
             WEBM.mimeType -> WEBM
             MOV.mimeType -> MOV
+            WEBP.mimeType -> WEBP
             else -> UNDEFINED
         }
     }


### PR DESCRIPTION
Closes #591

- Add `PhotoType.WEBP` to the photo type enumeration and MIME type mapping.
- Update `EncryptedImageFetcher` to handle WebP as a potentially animated image format, similar to GIF.
- Rename `playGif` to `playAnimation` in `EncryptedImageRequestData` to reflect broader support for animated formats (GIF and WebP).
- Update usage sites in `PhotoViewHolderContent` to use the new `playAnimation` parameter.
