### PR TITLE
Fix: Password error message not shown again

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockFragment.kt
@@ -43,9 +43,9 @@ import dev.leonlatsch.photok.uicomponnets.Dialogs
 import dev.leonlatsch.photok.uicomponnets.base.BaseActivity
 import dev.leonlatsch.photok.uicomponnets.bindings.BindableFragment
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -78,16 +78,16 @@ class UnlockFragment : BindableFragment<FragmentUnlockBinding>(R.layout.fragment
         }
 
         launchLifecycleAwareJob {
-            viewModel.unlockState.collectLatest {
+            viewModel.unlockState.collect {
                 when (it) {
                     UnlockState.CHECKING -> binding.loadingOverlay.show()
                     UnlockState.UNLOCKED -> goToGallery()
-                    UnlockState.LOCKED -> {
+                    UnlockState.UNLOCK_FAILED -> {
                         binding.loadingOverlay.hide()
                         binding.unlockWrongPasswordWarningTextView.show()
                     }
 
-                    UnlockState.UNDEFINED -> Unit
+                    UnlockState.INITIAL -> Unit
                 }
             }
         }

--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockState.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockState.kt
@@ -23,8 +23,8 @@ package dev.leonlatsch.photok.unlock.ui
  * @author Leon Latsch
  */
 enum class UnlockState {
-    UNDEFINED,
-    LOCKED,
+    INITIAL,
+    UNLOCK_FAILED,
     CHECKING,
     UNLOCKED
 }

--- a/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/unlock/ui/UnlockViewModel.kt
@@ -54,7 +54,7 @@ class UnlockViewModel @Inject constructor(
             notifyChange(BR.password, value)
         }
 
-    val unlockState: MutableStateFlow<UnlockState> = MutableStateFlow(UnlockState.UNDEFINED)
+    val unlockState: MutableStateFlow<UnlockState> = MutableStateFlow(UnlockState.INITIAL)
 
     /**
      * Tries to unlock the save.
@@ -62,17 +62,20 @@ class UnlockViewModel @Inject constructor(
      * Updates UnlockState.
      * Called by ui.
      */
-    fun unlock() = viewModelScope.launch {
+    fun unlock() {
         unlockState.update { UnlockState.CHECKING }
 
-        unlockState.update {
-            if (passwordManager.checkPassword(password)) {
-                encryptionManager.initialize(password)
-                legacyEncryptionManager.initialize(password)
+        viewModelScope.launch {
 
-                UnlockState.UNLOCKED
-            } else {
-                UnlockState.LOCKED
+            unlockState.update {
+                if (passwordManager.checkPassword(password)) {
+                    encryptionManager.initialize(password)
+                    legacyEncryptionManager.initialize(password)
+
+                    UnlockState.UNLOCKED
+                } else {
+                    UnlockState.UNLOCK_FAILED
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes the error that if editing the password and trying again, it
does not show the wrong password message again. Caused by migration to
using a flow.

Closes #643
