### PR TITLE
Fix: Freeze at NewFeaturesSheet

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/news/newfeatures/ui/NewFeaturesSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/news/newfeatures/ui/NewFeaturesSheet.kt
@@ -127,7 +127,10 @@ fun NewFeaturesSheet(overrideShow: Boolean = false, onDismissOverride: () -> Uni
 
         ModalBottomSheet(
             sheetState = state,
-            onDismissRequest = { visible = false },
+            onDismissRequest = {
+                visible = false
+                onDismissOverride()
+            },
             dragHandle = null,
             sheetGesturesEnabled = false,
             containerColor = Color.Transparent,


### PR DESCRIPTION
## Fix: App freeze when dismissing NewFeaturesSheet by tapping outside

### Problem
When opening the News/Changelog sheet from the About screen and dismissing it by tapping outside, the app would completely freeze.

The root cause was in `NewFeaturesSheet`: the `onDismissRequest` callback (triggered by an outside tap) only set the internal `visible` flag to `false`, but never called `onDismissOverride()`. As a result, `showNewsDialog` in `AboutScreen` remained `true`, causing Compose to immediately attempt to re-show the sheet while it was still in the middle of its hide animation, leading to a conflicting state that froze the UI.