### PR TITLE
Add optional collection of usage data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,8 @@ android {
     productFlavors {
         create("play") {
             dimension = "distribution"
+            buildConfigField("Boolean", "PLAY", "true")
+
             if (!isReleaseBuildInvocation) {
                 applicationIdSuffix = ".play"
                 versionNameSuffix = "-play-debug"
@@ -53,6 +55,8 @@ android {
 
         create("foss") {
             dimension = "distribution"
+            buildConfigField("Boolean", "PLAY", "false")
+
             if (!isReleaseBuildInvocation) {
                 applicationIdSuffix = ".foss"
                 versionNameSuffix = "-foss-debug"
@@ -107,7 +111,7 @@ licenseReport {
 }
 
 fun DependencyHandler.playImplementation(dependencyNotation: Any) {
-    add("fossImplementation", dependencyNotation)
+    add("playImplementation", dependencyNotation)
 }
 
 fun DependencyHandler.fossImplementation(dependencyNotation: Any) {
@@ -204,4 +208,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+
+    // Telemetry
+    implementation("com.telemetrydeck:kotlin-sdk:6.3.0")
 }

--- a/app/src/foss/kotlin/dev/leonlatsch/photok/telemetry/TelemetryDefaults.kt
+++ b/app/src/foss/kotlin/dev/leonlatsch/photok/telemetry/TelemetryDefaults.kt
@@ -1,0 +1,19 @@
+/*
+ *   Copyright 2020-2026 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.telemetry.domain
+
+const val TelemetryEnabledByDefault = false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <queries>
         <intent>

--- a/app/src/main/java/dev/leonlatsch/photok/BaseApplication.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/BaseApplication.kt
@@ -27,6 +27,7 @@ import dev.leonlatsch.photok.model.repositories.CleanupDeadFilesUseCase
 import dev.leonlatsch.photok.other.setAppDesign
 import dev.leonlatsch.photok.security.EncryptionManager
 import dev.leonlatsch.photok.settings.data.Config
+import dev.leonlatsch.photok.telemetry.domain.TelemetryService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,8 +52,12 @@ class BaseApplication : Application(), DefaultLifecycleObserver {
 
     @Inject
     lateinit var encryptionManager: EncryptionManager
+
     @Inject
     lateinit var cleanupDeadFilesUseCase: CleanupDeadFilesUseCase
+
+    @Inject
+    lateinit var telemetryService: TelemetryService
 
     val state = MutableStateFlow(ApplicationState.LOCKED)
 
@@ -63,6 +68,7 @@ class BaseApplication : Application(), DefaultLifecycleObserver {
     override fun onCreate() {
         super<Application>.onCreate()
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+        telemetryService.setup()
 
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/albums/ui/compose/AlbumsScreen.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/albums/ui/compose/AlbumsScreen.kt
@@ -33,6 +33,7 @@ import dev.leonlatsch.photok.gallery.albums.ui.AlbumsUiEvent
 import dev.leonlatsch.photok.gallery.albums.ui.AlbumsViewModel
 import dev.leonlatsch.photok.gallery.components.ImportSharedDialog
 import dev.leonlatsch.photok.news.newfeatures.ui.NewFeaturesSheet
+import dev.leonlatsch.photok.telemetry.ui.TelemetryOptInQuestionSheet
 import dev.leonlatsch.photok.ui.theme.AppTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -78,5 +79,6 @@ fun AlbumsScreen(viewModel: AlbumsViewModel) {
         }
 
         NewFeaturesSheet()
+        TelemetryOptInQuestionSheet()
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/compose/GalleryScreen.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/compose/GalleryScreen.kt
@@ -41,6 +41,7 @@ import dev.leonlatsch.photok.news.newfeatures.ui.NewFeaturesSheet
 import dev.leonlatsch.photok.sort.domain.SortConfig
 import dev.leonlatsch.photok.sort.ui.SortingMenu
 import dev.leonlatsch.photok.sort.ui.SortingMenuIconButton
+import dev.leonlatsch.photok.telemetry.ui.TelemetryOptInQuestionSheet
 import dev.leonlatsch.photok.ui.components.AppName
 import dev.leonlatsch.photok.ui.theme.AppTheme
 
@@ -121,5 +122,6 @@ fun GalleryScreen(
         }
 
         NewFeaturesSheet()
+        TelemetryOptInQuestionSheet()
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/news/newfeatures/ui/NewFeaturesSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/news/newfeatures/ui/NewFeaturesSheet.kt
@@ -67,6 +67,7 @@ import dev.leonlatsch.photok.other.openUrl
 import dev.leonlatsch.photok.settings.ui.compose.LocalConfig
 import dev.leonlatsch.photok.ui.components.AppName
 import dev.leonlatsch.photok.ui.theme.AppTheme
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 
@@ -115,6 +116,7 @@ fun NewFeaturesSheet(overrideShow: Boolean = false, onDismissOverride: () -> Uni
         config ?: return@LaunchedEffect
 
         if (config.systemLastFeatureVersionCode < FEATURE_VERSION_CODE) {
+            delay(300)
             visible = true
             config.systemLastFeatureVersionCode = FEATURE_VERSION_CODE
         }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/data/Config.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/data/Config.kt
@@ -22,6 +22,7 @@ import androidx.core.content.edit
 import dev.leonlatsch.photok.BuildConfig
 import dev.leonlatsch.photok.settings.domain.models.StartPage
 import dev.leonlatsch.photok.settings.domain.models.SystemDesignEnum
+import dev.leonlatsch.photok.telemetry.domain.TelemetryEnabledByDefault
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -152,9 +153,14 @@ class Config(context: Context) {
     var imageViewerMuteVideoPlayer: Boolean
         get() = getBoolean(IMAGE_VIEWER_MUTE_VIDEO_PLAYER, IMAGE_VIEWER_MUTE_VIDEO_PLAYER_DEFAULT)
         set(value) = putBoolean(IMAGE_VIEWER_MUTE_VIDEO_PLAYER, value)
+
     var imageViewerPlaybackSpeed: Float
         get() = getFloat(IMAGE_VIEWER_PLAYBACK_SPEED, IMAGE_VIEWER_PLAYBACK_SPEED_DEFAULT)
         set(value) = putFloat(IMAGE_VIEWER_PLAYBACK_SPEED, value)
+
+    var telemetryEnabled: Boolean
+        get() = getBoolean(TELEMETRY_ENABLED, TelemetryEnabledByDefault)
+        set(value) = putBoolean(TELEMETRY_ENABLED, value)
 
     // region put/get methods
 
@@ -262,5 +268,7 @@ class Config(context: Context) {
 
         const val IMAGE_VIEWER_PLAYBACK_SPEED = "imageViewer^playbackSpeed"
         const val IMAGE_VIEWER_PLAYBACK_SPEED_DEFAULT = 1f
+
+        const val TELEMETRY_ENABLED = "telemetry^enabled"
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/data/Config.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/data/Config.kt
@@ -162,6 +162,13 @@ class Config(context: Context) {
         get() = getBoolean(TELEMETRY_ENABLED, TelemetryEnabledByDefault)
         set(value) = putBoolean(TELEMETRY_ENABLED, value)
 
+    var telemetryAskedForOptIn: Boolean
+        get() = getBoolean(TELEMETRY_ASSSKED_FOR_OPT_IN, TELEMETRY_ASKED_FOR_OPT_IN_DEFAULT)
+        set(value) = putBoolean(TELEMETRY_ASSSKED_FOR_OPT_IN, value)
+
+    // In memory flags
+    var justFinishedSetup: Boolean = false
+
     // region put/get methods
 
     fun getString(key: String, default: String?) = preferences.getString(key, default)
@@ -270,5 +277,8 @@ class Config(context: Context) {
         const val IMAGE_VIEWER_PLAYBACK_SPEED_DEFAULT = 1f
 
         const val TELEMETRY_ENABLED = "telemetry^enabled"
+
+        const val TELEMETRY_ASSSKED_FOR_OPT_IN = "telemetry^askedForOptIn"
+        const val TELEMETRY_ASKED_FOR_OPT_IN_DEFAULT = false
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/domain/PreferenceScreenConfig.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/domain/PreferenceScreenConfig.kt
@@ -73,146 +73,161 @@ sealed interface Preference {
     ) : Preference
 }
 
-val PreferenceScreenConfigContent = listOf<PreferenceSection>(
-    PreferenceSection(
-        title = R.string.settings_category_app,
-        summary = null,
-        preferences = listOf(
-            Preference.Enum(
-                key = SYSTEM_DESIGN,
-                icon = R.drawable.ic_brush,
-                title = R.string.settings_app_design_title,
-                default = SYSTEM_DESIGN_DEFAULT,
-                possibleValues = SystemDesignEnum.entries,
+val PreferenceScreenConfigContent = buildList {
+    add(
+        PreferenceSection(
+            title = R.string.settings_category_app,
+            summary = null,
+            preferences = listOf(
+                Preference.Enum(
+                    key = SYSTEM_DESIGN,
+                    icon = R.drawable.ic_brush,
+                    title = R.string.settings_app_design_title,
+                    default = SYSTEM_DESIGN_DEFAULT,
+                    possibleValues = SystemDesignEnum.entries,
+                )
             )
         )
-    ),
-    PreferenceSection(
-        title = R.string.settings_category_gallery,
-        summary = null,
-        preferences = listOf(
-            Preference.Enum(
-                key = GALLERY_START_PAGE,
-                icon = R.drawable.ic_gallery_thumbnail,
-                title = R.string.settings_gallery_start_page_title,
-                default = GALLERY_START_PAGE_DEFAULT,
-                possibleValues = StartPage.entries,
-            )
-        )
-    ),
-    PreferenceSection(
-        title = R.string.settings_category_security,
-        summary = null,
-        preferences = listOf(
-            Preference.Switch(
-                key = SECURITY_ALLOW_SCREENSHOTS,
-                icon = R.drawable.ic_screen_lock,
-                title = R.string.settings_security_allow_screenshots_title,
-                summary = R.string.settings_security_allow_screenshots_summary,
-                default = SECURITY_ALLOW_SCREENSHOTS_DEFAULT,
-            ),
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_CHANGE_PASSWORD,
-                icon = R.drawable.ic_key,
-                title = R.string.change_password_title,
-                summary = R.string.settings_security_change_password_summary,
-            ),
-            Preference.Switch(
-                key = SECURITY_BIOMETRIC_AUTHENTICATION_ENABLED,
-                icon = R.drawable.ic_fingerprint,
-                title = R.string.settings_security_biometric_title,
-                summary = R.string.settings_security_biometric_summary,
-                default = SECURITY_BIOMETRIC_AUTHENTICATION_ENABLED_DEFAULT,
-            ),
-            Preference.Enum(
-                key = Config.SECURITY_LOCK_TIMEOUT,
-                icon = R.drawable.ic_schedule,
-                title = R.string.settings_security_timeout_title,
-                default = LockTimeout.FiveMinute,
-                possibleValues = LockTimeout.entries,
-            ),
-            Preference.Simple(
-                key = Config.SECURITY_DIAL_LAUNCH_CODE,
-                icon = R.drawable.ic_dialpad,
-                title = R.string.settings_security_launch_code_title,
-                summary = R.string.settings_security_launch_code_summary,
-            ),
-
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_HIDE_APP,
-                icon = R.drawable.ic_app_blocking,
-                title = R.string.settings_security_hide_app_title,
-                summary = R.string.settings_security_hide_app_summary,
-            ),
-        ),
-    ),
-    PreferenceSection(
-        title = R.string.settings_category_advanced,
-        summary = R.string.settings_category_advanced_summary,
-        preferences = listOf(
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_RESET,
-                icon = R.drawable.ic_warning,
-                title = R.string.settings_advanced_reset_title,
-                summary = R.string.settings_advanced_reset_summary,
-            ),
-            Preference.Simple(
-                SettingsFragment.KEY_ACTION_BACKUP,
-                icon = R.drawable.ic_save_as,
-                title = R.string.settings_advanced_backup_title,
-                summary = R.string.settings_advanced_backup_summary,
-            ),
-            Preference.Switch(
-                Config.ADVANCED_DELETE_IMPORTED_FILES,
-                icon = R.drawable.ic_delete,
-                title = R.string.settings_advanced_delete_imported_title,
-                summary = R.string.settings_advanced_delete_imported_summary,
-                default = Config.ADVANCED_DELETE_IMPORTED_FILES_DEFAULT,
-            ),
-            Preference.Switch(
-                Config.ADVANCED_DELETE_EXPORTED_FILES,
-                icon = R.drawable.ic_delete,
-                title = R.string.settings_advanced_delete_exported_title,
-                summary = R.string.settings_advanced_delete_exported_summary,
-                default = Config.ADVANCED_DELETE_EXPORTED_FILES_DEFAULT,
-            ),
-        ),
-    ),
-    PreferenceSection(
-        title = R.string.settings_other_title,
-        summary = null,
-        preferences = listOf(
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_FEEDBACK,
-                icon = R.drawable.ic_feedback,
-                title = R.string.settings_other_feedback_title,
-                summary = R.string.settings_other_feedback_summary,
-            ),
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_DONATE,
-                icon = R.drawable.ic_money,
-                title = R.string.settings_other_donate_title,
-                summary = R.string.settings_other_donate_summary,
-            ),
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_SOURCECODE,
-                icon = R.drawable.ic_code,
-                title = R.string.settings_other_sourcecode_title,
-                summary = R.string.settings_other_sourcecode_summary,
-            ),
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_CREDITS,
-                icon = R.drawable.ic_book,
-                title = R.string.settings_other_credits_title,
-                summary = R.string.settings_other_credits_summary,
-            ),
-            Preference.Simple(
-                key = SettingsFragment.KEY_ACTION_ABOUT,
-                icon = R.drawable.ic_info,
-                title = R.string.settings_other_about_title,
-                summary = R.string.settings_other_about_summary,
-            ),
-        ),
     )
-)
+    add(
+        PreferenceSection(
+            title = R.string.settings_category_gallery,
+            summary = null,
+            preferences = listOf(
+                Preference.Enum(
+                    key = GALLERY_START_PAGE,
+                    icon = R.drawable.ic_gallery_thumbnail,
+                    title = R.string.settings_gallery_start_page_title,
+                    default = GALLERY_START_PAGE_DEFAULT,
+                    possibleValues = StartPage.entries,
+                )
+            )
+        )
+    )
+    add(
+        PreferenceSection(
+            title = R.string.settings_category_security,
+            summary = null,
+            preferences = listOf(
+                Preference.Switch(
+                    key = SECURITY_ALLOW_SCREENSHOTS,
+                    icon = R.drawable.ic_screen_lock,
+                    title = R.string.settings_security_allow_screenshots_title,
+                    summary = R.string.settings_security_allow_screenshots_summary,
+                    default = SECURITY_ALLOW_SCREENSHOTS_DEFAULT,
+                ),
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_CHANGE_PASSWORD,
+                    icon = R.drawable.ic_key,
+                    title = R.string.change_password_title,
+                    summary = R.string.settings_security_change_password_summary,
+                ),
+                Preference.Switch(
+                    key = SECURITY_BIOMETRIC_AUTHENTICATION_ENABLED,
+                    icon = R.drawable.ic_fingerprint,
+                    title = R.string.settings_security_biometric_title,
+                    summary = R.string.settings_security_biometric_summary,
+                    default = SECURITY_BIOMETRIC_AUTHENTICATION_ENABLED_DEFAULT,
+                ),
+                Preference.Enum(
+                    key = Config.SECURITY_LOCK_TIMEOUT,
+                    icon = R.drawable.ic_schedule,
+                    title = R.string.settings_security_timeout_title,
+                    default = LockTimeout.FiveMinute,
+                    possibleValues = LockTimeout.entries,
+                ),
+                Preference.Simple(
+                    key = Config.SECURITY_DIAL_LAUNCH_CODE,
+                    icon = R.drawable.ic_dialpad,
+                    title = R.string.settings_security_launch_code_title,
+                    summary = R.string.settings_security_launch_code_summary,
+                ),
 
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_HIDE_APP,
+                    icon = R.drawable.ic_app_blocking,
+                    title = R.string.settings_security_hide_app_title,
+                    summary = R.string.settings_security_hide_app_summary,
+                ),
+            ),
+        )
+    )
+    add(
+        PreferenceSection(
+            title = R.string.settings_category_advanced,
+            summary = R.string.settings_category_advanced_summary,
+            preferences = listOf(
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_RESET,
+                    icon = R.drawable.ic_warning,
+                    title = R.string.settings_advanced_reset_title,
+                    summary = R.string.settings_advanced_reset_summary,
+                ),
+                Preference.Simple(
+                    SettingsFragment.KEY_ACTION_BACKUP,
+                    icon = R.drawable.ic_save_as,
+                    title = R.string.settings_advanced_backup_title,
+                    summary = R.string.settings_advanced_backup_summary,
+                ),
+                Preference.Switch(
+                    Config.ADVANCED_DELETE_IMPORTED_FILES,
+                    icon = R.drawable.ic_delete,
+                    title = R.string.settings_advanced_delete_imported_title,
+                    summary = R.string.settings_advanced_delete_imported_summary,
+                    default = Config.ADVANCED_DELETE_IMPORTED_FILES_DEFAULT,
+                ),
+                Preference.Switch(
+                    Config.ADVANCED_DELETE_EXPORTED_FILES,
+                    icon = R.drawable.ic_delete,
+                    title = R.string.settings_advanced_delete_exported_title,
+                    summary = R.string.settings_advanced_delete_exported_summary,
+                    default = Config.ADVANCED_DELETE_EXPORTED_FILES_DEFAULT,
+                ),
+            ),
+        )
+    )
+    add(
+        PreferenceSection(
+            title = R.string.settings_other_title,
+            summary = null,
+            preferences = listOf(
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_FEEDBACK,
+                    icon = R.drawable.ic_feedback,
+                    title = R.string.settings_other_feedback_title,
+                    summary = R.string.settings_other_feedback_summary,
+                ),
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_DONATE,
+                    icon = R.drawable.ic_money,
+                    title = R.string.settings_other_donate_title,
+                    summary = R.string.settings_other_donate_summary,
+                ),
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_SOURCECODE,
+                    icon = R.drawable.ic_code,
+                    title = R.string.settings_other_sourcecode_title,
+                    summary = R.string.settings_other_sourcecode_summary,
+                ),
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_CREDITS,
+                    icon = R.drawable.ic_book,
+                    title = R.string.settings_other_credits_title,
+                    summary = R.string.settings_other_credits_summary,
+                ),
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_TELEMETRY,
+                    icon = R.drawable.ic_data_object,
+                    title = R.string.settings_other_telemetry_title,
+                    summary = R.string.settings_other_telemetry_summary,
+                ),
+                Preference.Simple(
+                    key = SettingsFragment.KEY_ACTION_ABOUT,
+                    icon = R.drawable.ic_info,
+                    title = R.string.settings_other_about_title,
+                    summary = R.string.settings_other_about_summary,
+                ),
+            ),
+        )
+    )
+}

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/AboutScreen.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/AboutScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,7 +70,7 @@ fun AboutScreen(
     val context = LocalContext.current
     val fragment = LocalFragment.current
 
-    var showNewsDialog by remember { mutableStateOf(false) }
+    var showNewsDialog by rememberSaveable { mutableStateOf(false) }
 
     AppTheme {
         Scaffold(

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/SettingsFragment.kt
@@ -63,6 +63,7 @@ class SettingsFragment : Fragment() {
         const val KEY_ACTION_DONATE = "action_donate"
         const val KEY_ACTION_SOURCECODE = "action_sourcecode"
         const val KEY_ACTION_CREDITS = "action_credits"
+        const val KEY_ACTION_TELEMETRY = "action_telemetry"
         const val KEY_ACTION_ABOUT = "action_about"
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/SettingsFragment.kt
@@ -28,6 +28,7 @@ import dev.leonlatsch.photok.settings.data.Config
 import dev.leonlatsch.photok.settings.ui.compose.LocalConfig
 import dev.leonlatsch.photok.settings.ui.compose.SettingsScreen
 import dev.leonlatsch.photok.ui.LocalFragment
+import dev.leonlatsch.photok.ui.theme.AppTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -43,11 +44,13 @@ class SettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                CompositionLocalProvider(
-                    LocalFragment provides this@SettingsFragment,
-                    LocalConfig provides config,
-                ) {
-                    SettingsScreen()
+                AppTheme {
+                    CompositionLocalProvider(
+                        LocalFragment provides this@SettingsFragment,
+                        LocalConfig provides config,
+                    ) {
+                        SettingsScreen()
+                    }
                 }
             }
         }

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/compose/SettingsScreen.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/compose/SettingsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -90,6 +91,7 @@ import dev.leonlatsch.photok.settings.ui.changepassword.ChangePasswordDialog
 import dev.leonlatsch.photok.settings.ui.checkpassword.CheckPasswordDialog
 import dev.leonlatsch.photok.settings.ui.hideapp.SecretLaunchCodeDialog
 import dev.leonlatsch.photok.settings.ui.hideapp.ToggleAppVisibilityDialog
+import dev.leonlatsch.photok.telemetry.ui.TelemetryExplanationSheet
 import dev.leonlatsch.photok.ui.LocalFragment
 import dev.leonlatsch.photok.ui.theme.AppTheme
 import dev.leonlatsch.photok.uicomponnets.Dialogs
@@ -113,6 +115,7 @@ fun SettingsCallbacks(viewModel: SettingsViewModel) {
     }
 
     var showSecretLaunchCodeDialog by remember { mutableStateOf(false) }
+    var showUsageDataSheet by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         fragment ?: return@LaunchedEffect
@@ -192,6 +195,11 @@ fun SettingsCallbacks(viewModel: SettingsViewModel) {
             false
         }
 
+        viewModel.registerPreferenceCallback(SettingsFragment.KEY_ACTION_TELEMETRY) {
+            showUsageDataSheet = true
+            false
+        }
+
         viewModel.registerPreferenceCallback(SettingsFragment.KEY_ACTION_ABOUT) {
             fragment.findNavController().navigate(R.id.action_settingsFragment_to_aboutFragment)
             false
@@ -201,6 +209,11 @@ fun SettingsCallbacks(viewModel: SettingsViewModel) {
     SecretLaunchCodeDialog(
         show = showSecretLaunchCodeDialog,
         onDismissRequest = { showSecretLaunchCodeDialog = false },
+    )
+
+    TelemetryExplanationSheet(
+        visible = showUsageDataSheet,
+        onDismissRequest = { showUsageDataSheet = false },
     )
 }
 

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/compose/SettingsScreen.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/compose/SettingsScreen.kt
@@ -96,7 +96,8 @@ import dev.leonlatsch.photok.ui.LocalFragment
 import dev.leonlatsch.photok.ui.theme.AppTheme
 import dev.leonlatsch.photok.uicomponnets.Dialogs
 
-val LocalPreferencesValues: ProvidableCompositionLocal<Map<String, *>> = compositionLocalOf { emptyMap<String, String>() }
+val LocalPreferencesValues: ProvidableCompositionLocal<Map<String, *>> =
+    compositionLocalOf { emptyMap<String, String>() }
 
 fun createBackupFilename(): String {
     return "photok_backup_${BindingConverters.millisToFormattedDateConverter(System.currentTimeMillis())}.zip"
@@ -108,11 +109,15 @@ fun SettingsCallbacks(viewModel: SettingsViewModel) {
     val context = LocalContext.current
     val activity = LocalActivity.current
 
-    val backupLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
-        uri ?: return@rememberLauncherForActivityResult
-        fragment ?: return@rememberLauncherForActivityResult
-        BackupBottomSheetDialogFragment(uri, BackupStrategy.Name.Default).show(fragment.parentFragmentManager)
-    }
+    val backupLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
+            uri ?: return@rememberLauncherForActivityResult
+            fragment ?: return@rememberLauncherForActivityResult
+            BackupBottomSheetDialogFragment(
+                uri,
+                BackupStrategy.Name.Default
+            ).show(fragment.parentFragmentManager)
+        }
 
     var showSecretLaunchCodeDialog by remember { mutableStateOf(false) }
     var showUsageDataSheet by rememberSaveable { mutableStateOf(false) }
@@ -244,71 +249,86 @@ fun SettingsContent(
 ) {
     val fragment = LocalFragment.current
 
-    AppTheme {
-        val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-        Scaffold(
-            topBar = {
-                LargeTopAppBar(
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_title)
-                        )
-                    },
-                    scrollBehavior = scrollBehavior,
-                )
-            }
-        ) { contentPadding ->
-            Column(
-                verticalArrangement = Arrangement.spacedBy(20.dp),
-                modifier = Modifier
-                    .nestedScroll(scrollBehavior.nestedScrollConnection)
-                    .verticalScroll(rememberScrollState())
-                    .padding(contentPadding)
-            ) {
-                for (section in screenConfig.sections) {
-                    val isLast = section == screenConfig.sections.last()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    Scaffold(
+        topBar = {
+            LargeTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.settings_title)
+                    )
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        }
+    ) { contentPadding ->
+        Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier = Modifier
+                .nestedScroll(scrollBehavior.nestedScrollConnection)
+                .verticalScroll(rememberScrollState())
+                .padding(contentPadding)
+        ) {
+            for (section in screenConfig.sections) {
+                val isLast = section == screenConfig.sections.last()
 
-                    PreferenceSectionView(
-                        section = section,
-                    ) {
-                        for (preference in section.preferences) {
-                            when (preference) {
-                                is Preference.Simple -> {
-                                    PreferenceView(
-                                        icon = painterResource(preference.icon),
-                                        title = stringResource(preference.title),
-                                        summary = stringResource(preference.summary),
-                                        onClick = {
-                                            fragment ?: return@PreferenceView
-                                            handleUiEvent(SettingsUiEvent.OnPreferenceClick(preference, null))
-                                        }
-                                    )
-                                }
-                                is Preference.Switch -> {
-                                    PreferenceSwitchView(
-                                        preference = preference,
-                                        onSwitchChange = { value ->
-                                            fragment ?: return@PreferenceSwitchView
-                                            handleUiEvent(SettingsUiEvent.OnPreferenceClick(preference, value))
-                                        },
-                                    )
-                                }
-                                is Preference.Enum<*> -> {
-                                    PreferenceEnumView(
-                                        preference = preference,
-                                        onItemSelected = { value ->
-                                            fragment ?: return@PreferenceEnumView
-                                            handleUiEvent(SettingsUiEvent.OnPreferenceClick(preference, value))
-                                        },
-                                    )
-                                }
+                PreferenceSectionView(
+                    section = section,
+                ) {
+                    for (preference in section.preferences) {
+                        when (preference) {
+                            is Preference.Simple -> {
+                                PreferenceView(
+                                    icon = painterResource(preference.icon),
+                                    title = stringResource(preference.title),
+                                    summary = stringResource(preference.summary),
+                                    onClick = {
+                                        fragment ?: return@PreferenceView
+                                        handleUiEvent(
+                                            SettingsUiEvent.OnPreferenceClick(
+                                                preference,
+                                                null
+                                            )
+                                        )
+                                    }
+                                )
+                            }
+
+                            is Preference.Switch -> {
+                                PreferenceSwitchView(
+                                    preference = preference,
+                                    onSwitchChange = { value ->
+                                        fragment ?: return@PreferenceSwitchView
+                                        handleUiEvent(
+                                            SettingsUiEvent.OnPreferenceClick(
+                                                preference,
+                                                value
+                                            )
+                                        )
+                                    },
+                                )
+                            }
+
+                            is Preference.Enum<*> -> {
+                                PreferenceEnumView(
+                                    preference = preference,
+                                    onItemSelected = { value ->
+                                        fragment ?: return@PreferenceEnumView
+                                        handleUiEvent(
+                                            SettingsUiEvent.OnPreferenceClick(
+                                                preference,
+                                                value
+                                            )
+                                        )
+                                    },
+                                )
                             }
                         }
                     }
+                }
 
-                    if (!isLast) {
-                        HorizontalDivider()
-                    }
+                if (!isLast) {
+                    HorizontalDivider()
                 }
             }
         }
@@ -431,7 +451,7 @@ fun PreferenceSwitchView(
     modifier: Modifier = Modifier,
 ) {
     val preferencesValues = LocalPreferencesValues.current
-    
+
     val summary = stringResource(preference.summary)
     val value = preferencesValues[preference.key] as? Boolean ?: preference.default
 

--- a/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupViewModel.kt
@@ -25,6 +25,7 @@ import dev.leonlatsch.photok.other.extensions.empty
 import dev.leonlatsch.photok.security.EncryptionManager
 import dev.leonlatsch.photok.security.PasswordManager
 import dev.leonlatsch.photok.security.PasswordUtils
+import dev.leonlatsch.photok.settings.data.Config
 import dev.leonlatsch.photok.uicomponnets.bindings.ObservableViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -40,7 +41,8 @@ import javax.inject.Inject
 class SetupViewModel @Inject constructor(
     app: Application,
     val encryptionManager: EncryptionManager,
-    private val passwordManager: PasswordManager
+    private val passwordManager: PasswordManager,
+    private val config: Config,
 ) : ObservableViewModel(app) {
 
     //region binding properties
@@ -81,6 +83,7 @@ class SetupViewModel @Inject constructor(
         setupState = if (validateBothPasswords()) {
             passwordManager.storePassword(password)
             encryptionManager.initialize(this@SetupViewModel.password)
+            config.justFinishedSetup = true
             SetupState.FINISHED
         } else {
             SetupState.SETUP

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/domain/TelemetryService.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/domain/TelemetryService.kt
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2020-2026 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.telemetry.domain
+
+import android.content.Context
+import com.telemetrydeck.sdk.TelemetryDeck
+import com.telemetrydeck.sdk.providers.DefaultParameterProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.leonlatsch.photok.BuildConfig
+import dev.leonlatsch.photok.settings.data.Config
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TelemetryDeckAppId = "C2F73045-3C8D-4912-951B-FE9894262E86" // Not a secret. Fine to have in code
+
+@Singleton
+class TelemetryService @Inject constructor(
+    private val config: Config,
+    @ApplicationContext private val context: Context,
+) {
+    fun setup() {
+        if (config.telemetryEnabled) {
+            val builder = TelemetryDeck.Builder()
+                .appID(TelemetryDeckAppId)
+                .addProvider(
+                    DefaultParameterProvider(
+                        mapOf("flavor" to BuildConfig.FLAVOR)
+                    )
+                )
+                .showDebugLogs(BuildConfig.DEBUG)
+
+            TelemetryDeck.start(context, builder)
+        } else {
+            TelemetryDeck.stop()
+        }
+    }
+}

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,63 +50,84 @@ fun TelemetryExplanationSheet(visible: Boolean, onDismissRequest: () -> Unit) {
         val viewModel: TelemetryExplanationViewModel = hiltViewModel()
         val enabledState by viewModel.enabled.collectAsStateWithLifecycle()
 
-        val state = rememberModalBottomSheetState(
-            skipPartiallyExpanded = true
+        SheetContent(
+            enabled = enabledState,
+            updateEnabled = viewModel::updateTelemetryEnabled,
+            onDismissRequest = onDismissRequest,
         )
+    }
+}
 
-        AppTheme {
-            ModalBottomSheet(
-                sheetState = state,
-                onDismissRequest = onDismissRequest,
-                dragHandle = null,
-            ) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                    modifier = Modifier
-                        .verticalScroll(rememberScrollState())
-                        .padding(20.dp)
-                ) {
-                    Text(
-                        text = "Usage Data Collection", // TODO
-                        style = MaterialTheme.typography.titleLarge,
-                    )
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SheetContent(
+    enabled: Boolean,
+    updateEnabled: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val state = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
 
-                    Text(
-                        text = "Photok uses a privacy friendly analytics service called TelemetryDeck.", // TODO
-                    )
+    ModalBottomSheet(
+        sheetState = state,
+        onDismissRequest = onDismissRequest,
+        dragHandle = null,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(20.dp)
+        ) {
+            Text(
+                text = "Usage Data Collection", // TODO
+                style = MaterialTheme.typography.titleLarge,
+            )
 
-                    Text(
-                        text = "The data processed by TelemetryDeck is completely anonymized and does not allow any conclusions to be drawn about personal information." // TODO
-                    )
+            Text(
+                text = "Photok uses a privacy friendly analytics service called TelemetryDeck.", // TODO
+            )
 
-                    val context = LocalContext.current
-                    val ppUrl = stringResource(R.string.about_privacy_policy_url)
+            Text(
+                text = "The data processed by TelemetryDeck is completely anonymized and does not allow any conclusions to be drawn about personal information." // TODO
+            )
 
-                    TextButton(
-                        onClick = {
-                            context.openUrl(ppUrl)
-                        }
-                    ) {
-                        Text("Learn more") // TODO
-                    }
+            val context = LocalContext.current
+            val ppUrl = stringResource(R.string.about_privacy_policy_url)
 
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Allow collection of usage data", // TODO
-                            modifier = Modifier.weight(1f)
-                        )
-                        Switch(
-                            checked = enabledState,
-                            onCheckedChange = {
-                                viewModel.updateTelemetryEnabled(it)
-                            }
-                        )
-                    }
-
+            TextButton(
+                onClick = {
+                    context.openUrl(ppUrl)
                 }
+            ) {
+                Text("Learn more") // TODO
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Allow collection of usage data", // TODO
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = { updateEnabled(it) }
+                )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    AppTheme {
+        SheetContent(
+            enabled = true,
+            updateEnabled = {},
+            onDismissRequest = {},
+        )
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
@@ -37,30 +37,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.other.openUrl
-import dev.leonlatsch.photok.settings.data.Config
-import dev.leonlatsch.photok.telemetry.domain.TelemetryService
 import dev.leonlatsch.photok.ui.theme.AppTheme
-import kotlinx.coroutines.flow.MutableStateFlow
-import javax.inject.Inject
-
-@HiltViewModel
-class TelemetryExplanationViewModel @Inject constructor(
-    private val config: Config,
-    private val telemetryService: TelemetryService,
-) : ViewModel() {
-    val enabled = MutableStateFlow(config.telemetryEnabled) // TODO: Make this reactive
-
-    fun updateTelemetryEnabled(enabled: Boolean) {
-        config.telemetryEnabled = enabled
-        this.enabled.value = enabled
-        telemetryService.setup()
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
@@ -81,16 +81,16 @@ private fun SheetContent(
                 .padding(20.dp)
         ) {
             Text(
-                text = "Usage Data Collection", // TODO
+                text = stringResource(R.string.telemetry_sheet_title),
                 style = MaterialTheme.typography.titleLarge,
             )
 
             Text(
-                text = "Photok uses a privacy friendly analytics service called TelemetryDeck.", // TODO
+                text = stringResource(R.string.telemetry_sheet_paragraph_1),
             )
 
             Text(
-                text = "The data processed by TelemetryDeck is completely anonymized and does not allow any conclusions to be drawn about personal information." // TODO
+                text = stringResource(R.string.telemetry_sheet_paragraph_2),
             )
 
             val context = LocalContext.current
@@ -101,14 +101,14 @@ private fun SheetContent(
                     context.openUrl(ppUrl)
                 }
             ) {
-                Text("Learn more") // TODO
+                Text(stringResource(R.string.telemetry_learn_more))
             }
 
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "Allow collection of usage data", // TODO
+                    text = stringResource(R.string.telemetry_toggle),
                     modifier = Modifier.weight(1f)
                 )
                 Switch(

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
@@ -105,7 +105,8 @@ private fun SheetContent(
             }
 
             Row(
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
             ) {
                 Text(
                     text = stringResource(R.string.telemetry_toggle),

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationSheet.kt
@@ -1,0 +1,131 @@
+/*
+ *   Copyright 2020-2026 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.telemetry.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.leonlatsch.photok.R
+import dev.leonlatsch.photok.other.openUrl
+import dev.leonlatsch.photok.settings.data.Config
+import dev.leonlatsch.photok.telemetry.domain.TelemetryService
+import dev.leonlatsch.photok.ui.theme.AppTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class TelemetryExplanationViewModel @Inject constructor(
+    private val config: Config,
+    private val telemetryService: TelemetryService,
+) : ViewModel() {
+    val enabled = MutableStateFlow(config.telemetryEnabled) // TODO: Make this reactive
+
+    fun updateTelemetryEnabled(enabled: Boolean) {
+        config.telemetryEnabled = enabled
+        this.enabled.value = enabled
+        telemetryService.setup()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelemetryExplanationSheet(visible: Boolean, onDismissRequest: () -> Unit) {
+    if (visible) {
+        val viewModel: TelemetryExplanationViewModel = hiltViewModel()
+        val enabledState by viewModel.enabled.collectAsStateWithLifecycle()
+
+        val state = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true
+        )
+
+        AppTheme {
+            ModalBottomSheet(
+                sheetState = state,
+                onDismissRequest = onDismissRequest,
+                dragHandle = null,
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(20.dp)
+                ) {
+                    Text(
+                        text = "Usage Data Collection", // TODO
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+
+                    Text(
+                        text = "Photok uses a privacy friendly analytics service called TelemetryDeck.", // TODO
+                    )
+
+                    Text(
+                        text = "The data processed by TelemetryDeck is completely anonymized and does not allow any conclusions to be drawn about personal information." // TODO
+                    )
+
+                    val context = LocalContext.current
+                    val ppUrl = stringResource(R.string.about_privacy_policy_url)
+
+                    TextButton(
+                        onClick = {
+                            context.openUrl(ppUrl)
+                        }
+                    ) {
+                        Text("Learn more") // TODO
+                    }
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Allow collection of usage data", // TODO
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(
+                            checked = enabledState,
+                            onCheckedChange = {
+                                viewModel.updateTelemetryEnabled(it)
+                            }
+                        )
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryExplanationViewModel.kt
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2020-2026 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.telemetry.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.leonlatsch.photok.settings.data.Config
+import dev.leonlatsch.photok.telemetry.domain.TelemetryEnabledByDefault
+import dev.leonlatsch.photok.telemetry.domain.TelemetryService
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class TelemetryExplanationViewModel @Inject constructor(
+    private val config: Config,
+    private val telemetryService: TelemetryService,
+) : ViewModel() {
+
+    val enabled = config.valuesFlow.map {
+        it[Config.TELEMETRY_ENABLED] as? Boolean ?: TelemetryEnabledByDefault
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), TelemetryEnabledByDefault)
+
+    fun updateTelemetryEnabled(enabled: Boolean) {
+        config.telemetryEnabled = enabled
+        telemetryService.setup()
+    }
+}

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryOptInQuestionSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryOptInQuestionSheet.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices.NEXUS_5
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -104,24 +105,20 @@ private fun SheetContent(
                 .padding(20.dp)
         ) {
             Text(
-            text = "Help improve Photok",
+            text = stringResource(R.string.telemetry_sheet_title),
             style = MaterialTheme.typography.titleLarge,
         )
 
             Text(
-                text = "Photok can optionally send anonymous usage statistics to help improve the app."
+                text = stringResource(R.string.telemetry_sheet_paragraph_1)
             )
 
             Text(
-                text = "This information helps the developer understand how many people use Photok and which app versions are still active"
+                text = stringResource(R.string.telemetry_sheet_paragraph_2)
             )
 
             Text(
-                text = "No personal data, account information, or content you create in the app is collected."
-            )
-
-            Text(
-                text = "Sending anonymous usage data is optional and can be turned off at any time in Settings."
+                text = stringResource(R.string.telemetry_sheet_paragraph_3)
             )
 
             val context = LocalContext.current
@@ -132,7 +129,7 @@ private fun SheetContent(
                     context.openUrl(ppUrl)
                 }
             ) {
-                Text("Learn more") // TODO
+                Text(stringResource(R.string.telemetry_learn_more))
             }
 
             Column(
@@ -147,7 +144,7 @@ private fun SheetContent(
                         }.invokeOnCompletion { onDismissRequest() }
                     },
                 ) {
-                    Text("No thanks") // TODO
+                    Text(stringResource(R.string.telemetry_choice_no))
                 }
 
                 Button(
@@ -158,14 +155,14 @@ private fun SheetContent(
                         }.invokeOnCompletion { onDismissRequest() }
                     }
                 ) {
-                    Text("Enable anonymous usage statistics") // TODO
+                    Text(stringResource(R.string.telemetry_choice_yes))
                 }
             }
         }
     }
 }
 
-@Preview
+@Preview(device = NEXUS_5)
 @Composable
 private fun Preview() {
     AppTheme {

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryOptInQuestionSheet.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryOptInQuestionSheet.kt
@@ -18,19 +18,24 @@ package dev.leonlatsch.photok.telemetry.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -38,30 +43,45 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.other.openUrl
+import dev.leonlatsch.photok.settings.ui.compose.LocalConfig
+import dev.leonlatsch.photok.telemetry.domain.TelemetryEnabledByDefault
 import dev.leonlatsch.photok.ui.theme.AppTheme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TelemetryExplanationSheet(visible: Boolean, onDismissRequest: () -> Unit) {
-    if (visible) {
-        val viewModel: TelemetryViewModel = hiltViewModel()
-        val enabledState by viewModel.enabled.collectAsStateWithLifecycle()
+fun TelemetryOptInQuestionSheet() {
+    val config = LocalConfig.current
+    val viewModel: TelemetryViewModel = hiltViewModel()
 
+    var visible by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        config ?: return@LaunchedEffect
+
+        if (!TelemetryEnabledByDefault && !config.telemetryAskedForOptIn && !config.justFinishedSetup) {
+            delay(300)
+            visible = true
+            config.telemetryAskedForOptIn = true
+        }
+    }
+
+    if (visible) {
         SheetContent(
-            enabled = enabledState,
-            updateEnabled = viewModel::updateTelemetryEnabled,
-            onDismissRequest = onDismissRequest,
+            updateEnabled = {
+                viewModel.updateTelemetryEnabled(it)
+            },
+            onDismissRequest = { visible = false },
         )
     }
+
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SheetContent(
-    enabled: Boolean,
     updateEnabled: (Boolean) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -69,11 +89,14 @@ private fun SheetContent(
         skipPartiallyExpanded = true
     )
 
+    val scope = rememberCoroutineScope()
+
     ModalBottomSheet(
         sheetState = state,
         onDismissRequest = onDismissRequest,
         dragHandle = null,
     ) {
+
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier
@@ -81,16 +104,24 @@ private fun SheetContent(
                 .padding(20.dp)
         ) {
             Text(
-                text = "Usage Data Collection", // TODO
-                style = MaterialTheme.typography.titleLarge,
+            text = "Help improve Photok",
+            style = MaterialTheme.typography.titleLarge,
+        )
+
+            Text(
+                text = "Photok can optionally send anonymous usage statistics to help improve the app."
             )
 
             Text(
-                text = "Photok uses a privacy friendly analytics service called TelemetryDeck.", // TODO
+                text = "This information helps the developer understand how many people use Photok and which app versions are still active"
             )
 
             Text(
-                text = "The data processed by TelemetryDeck is completely anonymized and does not allow any conclusions to be drawn about personal information." // TODO
+                text = "No personal data, account information, or content you create in the app is collected."
+            )
+
+            Text(
+                text = "Sending anonymous usage data is optional and can be turned off at any time in Settings."
             )
 
             val context = LocalContext.current
@@ -104,17 +135,31 @@ private fun SheetContent(
                 Text("Learn more") // TODO
             }
 
-            Row(
-                verticalAlignment = Alignment.CenterVertically
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
-                    text = "Allow collection of usage data", // TODO
-                    modifier = Modifier.weight(1f)
-                )
-                Switch(
-                    checked = enabled,
-                    onCheckedChange = { updateEnabled(it) }
-                )
+                TextButton(
+                    onClick = {
+                        updateEnabled(false)
+                        scope.launch {
+                            state.hide()
+                        }.invokeOnCompletion { onDismissRequest() }
+                    },
+                ) {
+                    Text("No thanks") // TODO
+                }
+
+                Button(
+                    onClick = {
+                        updateEnabled(true)
+                        scope.launch {
+                            state.hide()
+                        }.invokeOnCompletion { onDismissRequest() }
+                    }
+                ) {
+                    Text("Enable anonymous usage statistics") // TODO
+                }
             }
         }
     }
@@ -125,7 +170,6 @@ private fun SheetContent(
 private fun Preview() {
     AppTheme {
         SheetContent(
-            enabled = true,
             updateEnabled = {},
             onDismissRequest = {},
         )

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/ui/TelemetryViewModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
-class TelemetryExplanationViewModel @Inject constructor(
+class TelemetryViewModel @Inject constructor(
     private val config: Config,
     private val telemetryService: TelemetryService,
 ) : ViewModel() {

--- a/app/src/main/res/drawable/ic_data_object.xml
+++ b/app/src/main/res/drawable/ic_data_object.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M560,800v-80h120q17,0 28.5,-11.5T720,680v-80q0,-38 22,-69t58,-44v-14q-36,-13 -58,-44t-22,-69v-80q0,-17 -11.5,-28.5T680,240L560,240v-80h120q50,0 85,35t35,85v80q0,17 11.5,28.5T840,400h40v160h-40q-17,0 -28.5,11.5T800,600v80q0,50 -35,85t-85,35L560,800ZM280,800q-50,0 -85,-35t-35,-85v-80q0,-17 -11.5,-28.5T120,560L80,560v-160h40q17,0 28.5,-11.5T160,360v-80q0,-50 35,-85t85,-35h120v80L280,240q-17,0 -28.5,11.5T240,280v80q0,38 -22,69t-58,44v14q36,13 58,44t22,69v80q0,17 11.5,28.5T280,720h120v80L280,800Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/drawable/ic_data_object.xml
+++ b/app/src/main/res/drawable/ic_data_object.xml
@@ -1,3 +1,19 @@
+<!--
+  ~   Copyright 2020-2026 Leon Latsch
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -204,6 +204,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">الاعتمادات</string>
     <string name="settings_other_credits_summary">المساهمون والاعتمادات</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">عن</string>
     <string name="settings_other_about_summary">معلومات حول Photok</string>
 
@@ -335,4 +337,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -206,6 +206,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Credits</string>
     <string name="settings_other_credits_summary">Mitwirkende und Credits</string>
+    <string name="settings_other_telemetry_title">Nutzungsstatistiken</string>
+    <string name="settings_other_telemetry_summary">Verwaltung der Erfassung von Nutzungsstatistiken</string>
     <string name="settings_other_about_title">Über</string>
     <string name="settings_other_about_summary">Informationen über Photok</string>
 
@@ -339,4 +341,14 @@
     <string name="video_player_pause">Pause</string>
     <string name="video_player_mute">Stummschalten</string>
     <string name="video_player_unmute">Stummschaltung aufheben</string>
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Hilf mit, Photok zu verbessern</string>
+    <string name="telemetry_sheet_paragraph_1">Photok kann optional anonyme Nutzungsstatistiken senden, um die App zu verbessern.</string>
+    <string name="telemetry_sheet_paragraph_2">Die verarbeiteten Daten sind vollständig anonymisiert und lassen keine Rückschlüsse auf personenbezogene Daten zu.</string>
+    <string name="telemetry_sheet_paragraph_3">Das Senden anonymer Nutzungsdaten ist optional und kann jederzeit in den Einstellungen deaktiviert werden.</string>
+    <string name="telemetry_learn_more">Mehr erfahren</string>
+    <string name="telemetry_choice_no">Nein danke</string>
+    <string name="telemetry_choice_yes">Anonyme Nutzungsdaten teilen</string>
+    <string name="telemetry_toggle">Teilen von Nutzungsdaten erlauben</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -206,6 +206,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Créditos</string>
     <string name="settings_other_credits_summary">Contribuyentes y créditos</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">Sobre</string>
     <string name="settings_other_about_summary">Sobre Photok</string>
 
@@ -337,4 +339,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -206,6 +206,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Crédits</string>
     <string name="settings_other_credits_summary">Contributeurs et crédits</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">À propos</string>
     <string name="settings_other_about_summary">Informations sur Photok</string>
 
@@ -337,4 +339,14 @@
     <string name="video_player_pause">Pause</string>
     <string name="video_player_mute">Désactiver le son</string>
     <string name="video_player_unmute">Activer le son</string>
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -204,6 +204,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Kredit</string>
     <string name="settings_other_credits_summary">Kontributor dan kredit</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">Tentang</string>
     <string name="settings_other_about_summary">Informasi tentang Photok</string>
 
@@ -335,4 +337,14 @@
     <string name="video_player_pause">Jeda</string>
     <string name="video_player_mute">Bisukan</string>
     <string name="video_player_unmute">Aktifkan Suara</string>
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -204,6 +204,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Crediti</string>
     <string name="settings_other_credits_summary">Collaboratori e crediti</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">Info</string>
     <string name="settings_other_about_summary">Informazioni su Photok</string>
 
@@ -335,4 +337,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -187,6 +187,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Credits</string>
     <string name="settings_other_credits_summary">Bijdragers en credits</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">Over</string>
     <string name="settings_other_about_summary">Informatie over Photok</string>
 
@@ -318,4 +320,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -201,6 +201,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Créditos</string>
     <string name="settings_other_credits_summary">Colaboradores e créditos</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">Sobre</string>
     <string name="settings_other_about_summary">Informações sobre o Photok</string>
 
@@ -336,4 +338,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -204,6 +204,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Титры</string>
     <string name="settings_other_credits_summary">Вкладчики и титры</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">О приложении</string>
     <string name="settings_other_about_summary">Информация о Photok</string>
 
@@ -335,4 +337,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -187,6 +187,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Katkıda Bulunanlar</string>
     <string name="settings_other_credits_summary">Katkıda bulunanlar ve teşekkürler</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">Hakkında</string>
     <string name="settings_other_about_summary">Photok hakkında bilgi</string>
 
@@ -320,4 +322,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -203,6 +203,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">شکریہ</string>
     <string name="settings_other_credits_summary">مدد کرنے والوں کے نام</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">بارے میں</string>
     <string name="settings_other_about_summary">ایپ کی معلومات</string>
 
@@ -333,4 +335,14 @@
     <string name="video_player_pause">Pause</string> <!-- TODO -->
     <string name="video_player_mute">Mute</string> <!-- TODO -->
     <string name="video_player_unmute">Unmute</string> <!-- TODO -->
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -202,6 +202,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">致谢</string>
     <string name="settings_other_credits_summary">贡献者和致谢</string>
+    <string name="settings_other_telemetry_title">Data collection</string> <!-- TODO -->
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string> <!-- TODO -->
     <string name="settings_other_about_title">关于</string>
     <string name="settings_other_about_summary">有关 Photok 的信息</string>
 
@@ -335,4 +337,14 @@
     <string name="video_player_pause">暂停</string>
     <string name="video_player_mute">静音</string>
     <string name="video_player_unmute">取消静音</string>
+
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string> <!-- TODO -->
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string> <!-- TODO -->
+    <string name="telemetry_learn_more">Learn more</string> <!-- TODO -->
+    <string name="telemetry_choice_no">No thanks</string> <!-- TODO -->
+    <string name="telemetry_choice_yes">Share anonymous usage data</string> <!-- TODO -->
+    <string name="telemetry_toggle">Allow collection of usage data</string> <!-- TODO -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,4 +337,14 @@
     <string name="video_player_pause">Pause</string>
     <string name="video_player_mute">Mute</string>
     <string name="video_player_unmute">Unmute</string>
+    
+    <!-- Telemetry -->
+    <string name="telemetry_sheet_title">Help improve Photok</string>
+    <string name="telemetry_sheet_paragraph_1">Photok can optionally send anonymous usage statistics to help improve the app.</string>
+    <string name="telemetry_sheet_paragraph_2">The data processed is completely anonymized and does not allow any conclusions to be drawn about personal information.</string>
+    <string name="telemetry_sheet_paragraph_3">Sending anonymous usage data is optional and can be turned off at any time in the settings.</string>
+    <string name="telemetry_learn_more">Learn more</string>
+    <string name="telemetry_choice_no">No thanks</string>
+    <string name="telemetry_choice_yes">Share anonymous usage data</string>
+    <string name="telemetry_toggle">Allow collection of usage data</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,7 +204,7 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Credits</string>
     <string name="settings_other_credits_summary">Contributors and credits</string>
-    <string name="settings_other_telemetry_title">Usage Data</string>
+    <string name="settings_other_telemetry_title">Data collection</string>
     <string name="settings_other_telemetry_summary">Manage collection of usage data</string>
     <string name="settings_other_about_title">About</string>
     <string name="settings_other_about_summary">Information about Photok</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,8 @@
     <string name="settings_other_sourcecode_url">https://github.com/leonlatsch/Photok</string>
     <string name="settings_other_credits_title">Credits</string>
     <string name="settings_other_credits_summary">Contributors and credits</string>
+    <string name="settings_other_telemetry_title">Usage Data</string>
+    <string name="settings_other_telemetry_summary">Manage collection of usage data</string>
     <string name="settings_other_about_title">About</string>
     <string name="settings_other_about_summary">Information about Photok</string>
 

--- a/app/src/play/kotlin/dev/leonlatsch/photok/telemetry/domain/TelemetryDefaults.kt
+++ b/app/src/play/kotlin/dev/leonlatsch/photok/telemetry/domain/TelemetryDefaults.kt
@@ -1,0 +1,19 @@
+/*
+ *   Copyright 2020-2026 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.telemetry.domain
+
+const val TelemetryEnabledByDefault = true


### PR DESCRIPTION
This PR introduces optional collection of anonymous usage data.

The decision to use TelemetryDeck was discussed in #289.

In addition to in app texts I also updated the Privacy Policy to be very clear on who collects what. So users with concerns have 100% knowledge and transparency.

## Key differences between Google Play and FOSS builds

### Google Play
Telemetry is *enabled* by default. Users can disable it at any time in the settings.

### FOSS (F-Droid, GitHub, etc.)
Telemetry is *disabled* by default. Users can enable it at any time in the settings.  
In addition, Photok will prompt the user to enable telemetry after the first unlock (not during initial setup).

No data is transmitted unless the user has explicitly opted in. This behavior is required to avoid the *Tracking* anti-feature flag in F-Droid and aligns with user expectations for apps installed from F-Droid.

## Screenshots
<img width="300" height="2340" alt="Screenshot_20260312_110647" src="https://github.com/user-attachments/assets/4ff9e53b-1bee-4362-8590-e1f5d9a3075f" />
<img width="300" height="2340" alt="Screenshot_20260312_110703" src="https://github.com/user-attachments/assets/c054c17a-5ebd-4bdb-a229-29f2e94f4efa" />
