### PR TITLE
Performance: use thumbnails for album grid images

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/gallery/albums/Mappers.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/albums/Mappers.kt
@@ -52,13 +52,8 @@ fun Album.toUi(): AlbumItem = AlbumItem(
     name = name,
     itemCount = files.size,
     albumCover = files.firstOrNull()?.let { firstPhoto ->
-        val albumCoverFileName = if (firstPhoto.type.isVideo) {
-            firstPhoto.internalVideoPreviewFileName
-        } else {
-            firstPhoto.internalFileName
-        }
         AlbumCover(
-            filename = albumCoverFileName,
+            filename = firstPhoto.internalThumbnailFileName,
             mimeType = firstPhoto.type.mimeType
         )
     }


### PR DESCRIPTION
Closes #534

This is better suitable now because thumbnail quality has significantly
improved.
