### PR TITLE
Telemetry: Inject App Id in CI to avoid forks from accidentally using Photoks app id

### DIFF
--- a/.github/workflows/build-signed-release.yml
+++ b/.github/workflows/build-signed-release.yml
@@ -27,10 +27,14 @@ jobs:
       # Build .aab file
       - name: Build GPlay AAB
         run: ./gradlew bundlePlayRelease
+        env:
+          ORG_GRADLE_PROJECT_telemetryDeckAppId: ${{ secrets.TELEMETRY_DECK_APP_ID }}
       
       # Build .apk file
       - name: Build FOSS APK
         run: ./gradlew assembleFossRelease
+        env:
+          ORG_GRADLE_PROJECT_telemetryDeckAppId: ${{ secrets.TELEMETRY_DECK_APP_ID }}
       
       # Sign .aab file
       - name: Sign AAB

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,12 @@ android {
         base {
             archivesName = "photok-$versionName"
         }
+
+        buildConfigField(
+            "String",
+            "TELEMETRY_DECK_APP_ID",
+            "\"${project.findProperty("telemetryDeckAppId") ?: ""}\""
+        )
     }
 
     flavorDimensions += "distribution"

--- a/app/src/main/java/dev/leonlatsch/photok/telemetry/domain/TelemetryService.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/telemetry/domain/TelemetryService.kt
@@ -25,8 +25,6 @@ import dev.leonlatsch.photok.settings.data.Config
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val TelemetryDeckAppId = "C2F73045-3C8D-4912-951B-FE9894262E86" // Not a secret. Fine to have in code
-
 enum class Signal {
     OnboardingFinished,
     SetupCompleted,
@@ -38,9 +36,11 @@ class TelemetryService @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     fun setup() {
-        if (config.telemetryEnabled) {
+        val telemetryDeckAppId = BuildConfig.TELEMETRY_DECK_APP_ID
+
+        if (config.telemetryEnabled && telemetryDeckAppId.isNotBlank()) {
             val builder = TelemetryDeck.Builder()
-                .appID(TelemetryDeckAppId)
+                .appID(telemetryDeckAppId)
                 .addProvider(
                     DefaultParameterProvider(
                         mapOf(


### PR DESCRIPTION
This fixes 2 problems:
- Forks mess up the data and therefore the reports I have configured
- Forks use my personal quata that I eventually have to pay for :(
