### PR TITLE
Improvement: Redesign Password Strength Check

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/encryption/domain/PasswordUtils.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/encryption/domain/PasswordUtils.kt
@@ -18,9 +18,11 @@ package dev.leonlatsch.photok.encryption.domain
 
 import androidx.lifecycle.LiveData
 import dev.leonlatsch.photok.encryption.domain.PasswordUtils.PASSWORD_MIN_LENGTH
+import dev.leonlatsch.photok.encryption.domain.models.PasswordStrength
+import kotlin.math.log2
 
 /**
- * Utils to validate passwords.
+ * Utils to validate passwords and estimate their strength.
  *
  * @since 1.0.0
  * @author Leon Latsch
@@ -34,7 +36,7 @@ object PasswordUtils {
             && password.length >= PASSWORD_MIN_LENGTH
 
     /**
-     * Indicates if two password equal.
+     * Indicates if two passwords are equal.
      */
     fun passwordsNotEmptyAndEqual(password: String, confirmPassword: String) = password.isNotEmpty()
             && confirmPassword.isNotEmpty()
@@ -44,7 +46,7 @@ object PasswordUtils {
         passwordsNotEmptyAndEqual(password.value!!, confirmPassword.value!!)
 
     /**
-     * Indicates if two password are valid and equal.
+     * Indicates if two passwords are valid and equal.
      */
     fun validatePasswords(password: String, confirmPassword: String) = validatePassword(password)
             && validatePassword(confirmPassword)
@@ -53,5 +55,142 @@ object PasswordUtils {
     fun validatePasswords(password: LiveData<String>, confirmPassword: LiveData<String>) =
         validatePasswords(password.value!!, confirmPassword.value!!)
 
-    private const val PASSWORD_MIN_LENGTH = 6
+    /**
+     * Estimates the strength of [password] as a [PasswordStrength], using an entropy heuristic
+     * that rewards length and character variety but penalizes repeated or sequential patterns.
+     * Does not check against dictionaries or known-breached passwords.
+     */
+    fun calculateStrength(password: String): PasswordStrength {
+        if (password.length < PASSWORD_MIN_LENGTH) return PasswordStrength.VERY_WEAK
+
+        val rawEntropyBits = password.length * log2(characterPoolSize(password).toDouble())
+        val entropyBits = rawEntropyBits * patternPenaltyFactor(password)
+
+        return when {
+            entropyBits >= VERY_STRONG_ENTROPY_THRESHOLD_BITS -> PasswordStrength.VERY_STRONG
+            entropyBits >= STRONG_ENTROPY_THRESHOLD_BITS -> PasswordStrength.STRONG
+            entropyBits >= MODERATE_ENTROPY_THRESHOLD_BITS -> PasswordStrength.MODERATE
+            entropyBits >= WEAK_ENTROPY_THRESHOLD_BITS -> PasswordStrength.WEAK
+            else -> PasswordStrength.VERY_WEAK
+        }
+    }
+
+    /**
+     * Size of the character pool [password] draws from, based on which categories are present.
+     */
+    private fun characterPoolSize(password: String): Int {
+        var poolSize = 0
+        if (password.any { it.isLowerCase() }) poolSize += LOWERCASE_POOL_SIZE
+        if (password.any { it.isUpperCase() }) poolSize += UPPERCASE_POOL_SIZE
+        if (password.any { it.isDigit() }) poolSize += DIGIT_POOL_SIZE
+        if (password.any { !it.isLetterOrDigit() }) poolSize += SYMBOL_POOL_SIZE
+        return poolSize.coerceAtLeast(1)
+    }
+
+    /**
+     * Factor in `(0, 1]` that discounts entropy for runs of repeated/sequential characters or
+     * adjacent keyboard keys (min length [MIN_PATTERN_RUN_LENGTH]). `1.0` if [password] has none.
+     */
+    private fun patternPenaltyFactor(password: String): Double {
+        val patternedCharCount = (sequentialPatternedCharCount(password) + keyboardPatternedCharCount(password))
+            .coerceAtMost(password.length)
+        val patternedRatio = patternedCharCount.toDouble() / password.length
+        return 1.0 - (patternedRatio * PATTERN_PENALTY_WEIGHT)
+    }
+
+    /**
+     * Counts characters that are part of a repeated or ascending/descending character-code run,
+     * e.g. "aaaa" or "1234".
+     */
+    private fun sequentialPatternedCharCount(password: String): Int {
+        var patternedCharCount = 0
+        var i = 0
+
+        while (i < password.length - 1) {
+            val step = password[i + 1].code - password[i].code
+            if (step == -1 || step == 0 || step == 1) {
+                var runLength = 2
+                while (i + runLength < password.length
+                    && password[i + runLength].code - password[i + runLength - 1].code == step
+                ) {
+                    runLength++
+                }
+                if (runLength >= MIN_PATTERN_RUN_LENGTH) {
+                    patternedCharCount += runLength
+                }
+                i += runLength
+            } else {
+                i++
+            }
+        }
+
+        return patternedCharCount
+    }
+
+    /**
+     * Counts characters that are part of a run along a keyboard row, e.g. "qwerty" or "asdfgh".
+     */
+    private fun keyboardPatternedCharCount(password: String): Int {
+        var patternedCharCount = 0
+        var i = 0
+        val lower = password.lowercase()
+
+        while (i < lower.length - 1) {
+            val step = keyboardStep(lower[i], lower[i + 1])
+            if (step != null) {
+                var runLength = 2
+                while (i + runLength < lower.length
+                    && keyboardStep(lower[i + runLength - 1], lower[i + runLength]) == step
+                ) {
+                    runLength++
+                }
+                if (runLength >= MIN_PATTERN_RUN_LENGTH) {
+                    patternedCharCount += runLength
+                }
+                i += runLength
+            } else {
+                i++
+            }
+        }
+
+        return patternedCharCount
+    }
+
+    /**
+     * Column difference between [a] and [b] if both are letters/digits on the same keyboard row
+     * and adjacent to each other, `null` otherwise.
+     */
+    private fun keyboardStep(a: Char, b: Char): Int? {
+        val posA = KEYBOARD_POSITIONS[a] ?: return null
+        val posB = KEYBOARD_POSITIONS[b] ?: return null
+        if (posA.first != posB.first) return null
+        val step = posB.second - posA.second
+        return step.takeIf { it == 1 || it == -1 }
+    }
+
+    private val KEYBOARD_ROWS = listOf(
+        "1234567890",
+        "qwertyuiop",
+        "asdfghjkl",
+        "zxcvbnm"
+    )
+
+    private val KEYBOARD_POSITIONS: Map<Char, Pair<Int, Int>> = KEYBOARD_ROWS
+        .flatMapIndexed { row, chars -> chars.mapIndexed { col, char -> char to (row to col) } }
+        .toMap()
+
+    private const val PASSWORD_MIN_LENGTH = 8
+
+    private const val LOWERCASE_POOL_SIZE = 26
+    private const val UPPERCASE_POOL_SIZE = 26
+    private const val DIGIT_POOL_SIZE = 10
+    private const val SYMBOL_POOL_SIZE = 33
+
+    private const val MIN_PATTERN_RUN_LENGTH = 3
+    private const val PATTERN_PENALTY_WEIGHT = 0.75
+
+    private const val WEAK_ENTROPY_THRESHOLD_BITS = 20.0
+    private const val MODERATE_ENTROPY_THRESHOLD_BITS = 35.0
+    private const val STRONG_ENTROPY_THRESHOLD_BITS = 55.0
+    private const val VERY_STRONG_ENTROPY_THRESHOLD_BITS = 75.0
 }

--- a/app/src/main/java/dev/leonlatsch/photok/encryption/domain/PasswordUtils.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/encryption/domain/PasswordUtils.kt
@@ -179,7 +179,7 @@ object PasswordUtils {
         .flatMapIndexed { row, chars -> chars.mapIndexed { col, char -> char to (row to col) } }
         .toMap()
 
-    private const val PASSWORD_MIN_LENGTH = 8
+    private const val PASSWORD_MIN_LENGTH = 6
 
     private const val LOWERCASE_POOL_SIZE = 26
     private const val UPPERCASE_POOL_SIZE = 26

--- a/app/src/main/java/dev/leonlatsch/photok/encryption/domain/models/PasswordStrength.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/encryption/domain/models/PasswordStrength.kt
@@ -1,0 +1,28 @@
+/*
+ *   Copyright 2020-2026 Leon Latsch
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package dev.leonlatsch.photok.encryption.domain.models
+
+/**
+ * Represents the estimated strength of a password, ordered from weakest to strongest.
+ */
+enum class PasswordStrength {
+    VERY_WEAK,
+    WEAK,
+    MODERATE,
+    STRONG,
+    VERY_STRONG
+}

--- a/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
@@ -59,8 +59,8 @@ class SetupFragment : BindableFragment<FragmentSetupBinding>(R.layout.fragment_s
         finishOnBackWhileStarted()
 
         if (BuildConfig.DEBUG) {
-            viewModel.password = "abcd1234"
-            viewModel.confirmPassword = "abcd1234"
+            viewModel.password = "abc123"
+            viewModel.confirmPassword = "abc123"
         }
 
         viewModel.addOnPropertyChange<String>(BR.password) {

--- a/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/setup/ui/SetupFragment.kt
@@ -26,6 +26,8 @@ import dev.leonlatsch.photok.BR
 import dev.leonlatsch.photok.BuildConfig
 import dev.leonlatsch.photok.R
 import dev.leonlatsch.photok.databinding.FragmentSetupBinding
+import dev.leonlatsch.photok.encryption.domain.PasswordUtils
+import dev.leonlatsch.photok.encryption.domain.models.PasswordStrength
 import dev.leonlatsch.photok.gallery.ui.navigation.NavigateToGallery
 import dev.leonlatsch.photok.other.extensions.empty
 import dev.leonlatsch.photok.other.extensions.finishOnBackWhileStarted
@@ -57,28 +59,27 @@ class SetupFragment : BindableFragment<FragmentSetupBinding>(R.layout.fragment_s
         finishOnBackWhileStarted()
 
         if (BuildConfig.DEBUG) {
-            viewModel.password = "abc123"
-            viewModel.confirmPassword = "abc123"
+            viewModel.password = "abcd1234"
+            viewModel.confirmPassword = "abcd1234"
         }
 
         viewModel.addOnPropertyChange<String>(BR.password) {
             if (it.isNotEmpty()) {
-                val value = when (it.length) {
-                    1, 2, 3, 4, 5 -> {
-                        binding.setupPasswordStrengthValue.setTextColor(requireContext().getColor(R.color.darkRed))
-                        getString(R.string.setup_password_strength_weak)
-                    }
-                    6, 7, 8, 9, 10 -> {
-                        binding.setupPasswordStrengthValue.setTextColor(requireContext().getColor(R.color.darkYellow))
-                        getString(R.string.setup_password_strength_moderate)
-                    }
-                    else -> {
-                        binding.setupPasswordStrengthValue.setTextColor(requireContext().getColor(R.color.darkGreen))
-                        getString(R.string.setup_password_strength_strong)
-                    }
+                val (colorRes, textRes) = when (PasswordUtils.calculateStrength(it)) {
+                    PasswordStrength.VERY_WEAK ->
+                        R.color.darkRedStrong to R.string.setup_password_strength_very_weak
+                    PasswordStrength.WEAK ->
+                        R.color.darkRed to R.string.setup_password_strength_weak
+                    PasswordStrength.MODERATE ->
+                        R.color.darkYellow to R.string.setup_password_strength_moderate
+                    PasswordStrength.STRONG ->
+                        R.color.darkGreen to R.string.setup_password_strength_strong
+                    PasswordStrength.VERY_STRONG ->
+                        R.color.colorPrimaryDark to R.string.setup_password_strength_very_strong
                 }
+                binding.setupPasswordStrengthValue.setTextColor(requireContext().getColor(colorRes))
+                binding.setupPasswordStrengthValue.text = getString(textRes)
                 binding.setupPasswordStrengthLayout.show()
-                binding.setupPasswordStrengthValue.text = value
             } else {
                 binding.setupPasswordStrengthLayout.hide()
             }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -15,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">حقوق النشر  \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -50,9 +49,11 @@
     <string name="setup_confirm_password">أكد رقمك السري </string>
     <string name="setup_password_strength_label">قوة كلمة المرور: </string>
     <string name="setup_button">إنشاء</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">ضعيف </string>
     <string name="setup_password_strength_moderate">معتدل </string>
     <string name="setup_password_strength_strong">قوي </string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 كلمة المرور غير مطابقة </string>
     <string name="setupSetup">تنصيب</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~   Copyright 2020–2026 Leon Latsch
   ~
   ~   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020-2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -51,9 +49,11 @@
     <string name="setup_confirm_password">Passwort bestätigen</string>
     <string name="setup_password_strength_label">Passwort stärke:</string>
     <string name="setup_button">Erstellen</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Schwach</string>
     <string name="setup_password_strength_moderate">Moderat</string>
     <string name="setup_password_strength_strong">Stark</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Die Passwörter stimmen nicht überein</string>
     <string name="setupSetup">Setup</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~   Copyright 2020–2026 Leon Latsch
   ~
   ~   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020-2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -51,9 +49,11 @@
     <string name="setup_confirm_password">Confirma tu contraseña</string>
     <string name="setup_password_strength_label">Longitud de la contraseña:</string>
     <string name="setup_button">Crear</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Débil</string>
     <string name="setup_password_strength_moderate">Moderada</string>
     <string name="setup_password_strength_strong">Fuerte</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Las contraseñas no coinciden</string>
     <string name="setupSetup">Inicio</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~   Copyright 2020–2026 Leon Latsch
   ~
   ~   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -51,9 +49,11 @@
     <string name="setup_confirm_password">Confirmer votre mot de passe</string>
     <string name="setup_password_strength_label">Force du mot de passe :</string>
     <string name="setup_button">Créer</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Faible</string>
     <string name="setup_password_strength_moderate">Modéré</string>
     <string name="setup_password_strength_strong">Fort</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Les mots de passe ne correspondent pas</string>
     <string name="setupSetup">Installation</string>
 

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -15,7 +15,6 @@
 -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -50,9 +49,11 @@
     <string name="setup_confirm_password">Konfirmasi kata sandimu</string>
     <string name="setup_password_strength_label">Kekuatan kata sandi:</string>
     <string name="setup_button">Buat</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Lemah</string>
     <string name="setup_password_strength_moderate">Sedang</string>
     <string name="setup_password_strength_strong">Kuat</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Kata sandi tidak cocok</string>
     <string name="setupSetup">Pengaturan Awal</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -15,7 +15,6 @@
 -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -50,9 +49,11 @@
     <string name="setup_confirm_password">Conferma la tua password</string>
     <string name="setup_password_strength_label">Sicurezza password:</string>
     <string name="setup_button">Crea</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Debole</string>
     <string name="setup_password_strength_moderate">Moderata</string>
     <string name="setup_password_strength_strong">Forte</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Le password non corrispondono</string>
     <string name="setupSetup">Configurazione</string>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -31,6 +31,7 @@
     <color name="dotUnselectedColor">@color/darkGray</color>
 
     <!-- Explicit -->
+    <color name="darkRedStrong">#B00020</color>
     <color name="darkRed">#FF0000</color>
     <color name="darkYellow">#FF7E00</color>
     <color name="darkGreen">#44CC00</color>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,3 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+~   Copyright 2020–2026 Leon Latsch
+~
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~        http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+
 <resources>
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020-2026 Leon Latsch</string>
@@ -33,9 +49,11 @@
     <string name="setup_confirm_password">Bevestig je wachtwoord</string>
     <string name="setup_password_strength_label">Wachtwoord sterkte:</string>
     <string name="setup_button">Creëren</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Zwak</string>
     <string name="setup_password_strength_moderate">Gematigd</string>
     <string name="setup_password_strength_strong">Sterk</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Wachtwoorden komen niet overeen</string>
     <string name="setupSetup">Opstelling</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~   Copyright 2020–2026 Leon Latsch
   ~
   ~   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Direitos autorais \u00A9 2020-2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -51,9 +49,11 @@
     <string name="setup_confirm_password">Confirmar sua senha</string>
     <string name="setup_password_strength_label">Força da senha:</string>
     <string name="setup_button">Criar</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Fraca</string>
     <string name="setup_password_strength_moderate">Moderada</string>
     <string name="setup_password_strength_strong">Forte</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Senhas não correspondem</string>
     <string name="setupSetup">Configurar</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -15,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -50,9 +49,11 @@
     <string name="setup_confirm_password">Подтвердите свой пароль</string>
     <string name="setup_password_strength_label">Сложность пароля:</string>
     <string name="setup_button">Создать</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Слабая</string>
     <string name="setup_password_strength_moderate">Средняя</string>
     <string name="setup_password_strength_strong">Сильная</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Пароли не совпадают</string>
     <string name="setupSetup">Настроить</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,3 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+~   Copyright 2020–2026 Leon Latsch
+~
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~        http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+
 <resources>
     <!-- COMMON -->
     <string name="common_copyright_notice">Telif Hakkı \u00A9 2020–2026 Leon Latsch</string>
@@ -33,9 +49,11 @@
     <string name="setup_confirm_password">Şifrenizi onaylayın</string>
     <string name="setup_password_strength_label">Şifre Gücü:</string>
     <string name="setup_button">Oluştur</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">Zayıf</string>
     <string name="setup_password_strength_moderate">Orta</string>
     <string name="setup_password_strength_strong">Güçlü</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 Şifreler eşleşmiyor</string>
     <string name="setupSetup">Kurulum</string>
 

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -14,9 +14,7 @@
   ~   limitations under the License.
   -->
 
-
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">کاپی رائٹ \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -51,9 +49,11 @@
     <string name="setup_confirm_password">پاس ورڈ دوبارہ لکھیں</string>
     <string name="setup_password_strength_label">پاس ورڈ کتنا مضبوط ہے:</string>
     <string name="setup_button">بنائیں</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">کمزور</string>
     <string name="setup_password_strength_moderate">درمیانہ</string>
     <string name="setup_password_strength_strong">بہت مضبوط</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0۰ پاس ورڈ ایک جیسے نہیں ہیں</string>
     <string name="setupSetup">تیاری</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -15,7 +15,6 @@
   -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">版权所有 \u00A9 2020-2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -50,9 +49,11 @@
     <string name="setup_confirm_password">确认你的密码</string>
     <string name="setup_password_strength_label">密码强度:</string>
     <string name="setup_button">创建</string>
+    <string name="setup_password_strength_very_weak">Very weak</string> <!-- TODO -->
     <string name="setup_password_strength_weak">弱</string>
     <string name="setup_password_strength_moderate">中等</string>
     <string name="setup_password_strength_strong">强</string>
+    <string name="setup_password_strength_very_strong">Very strong</string> <!-- TODO -->
     <string name="setup_password_match_warning">\u26A0 密码不匹配</string>
     <string name="setupSetup">设置</string>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -31,6 +31,7 @@
     <color name="dotUnselectedColor">@color/lightGray</color>
 
     <!-- Explicit -->
+    <color name="darkRedStrong">#B00020</color>
     <color name="darkRed">#FF0000</color>
     <color name="darkYellow">#FF7E00</color>
     <color name="darkGreen">#44CC00</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
 -->
 
 <resources>
-
     <!-- COMMON -->
     <string name="common_copyright_notice">Copyright \u00A9 2020–2026 Leon Latsch</string>
     <string name="common_slash">/</string>
@@ -50,9 +49,11 @@
     <string name="setup_confirm_password">Confirm your password</string>
     <string name="setup_password_strength_label">Password strength:</string>
     <string name="setup_button">Create</string>
+    <string name="setup_password_strength_very_weak">Very weak</string>
     <string name="setup_password_strength_weak">Weak</string>
     <string name="setup_password_strength_moderate">Moderate</string>
     <string name="setup_password_strength_strong">Strong</string>
+    <string name="setup_password_strength_very_strong">Very strong</string>
     <string name="setup_password_match_warning">\u26A0 Passwords do not match</string>
     <string name="setupSetup">Setup</string>
 


### PR DESCRIPTION
## Why
The old meter just went off character count (`<6`, `6-10`, `>10`), so a 12-char string of nothing but `aaaaaaaaaaaa` scored the same as something actually random, and mixing in numbers or symbols never counted for anything. Wanted something that actually tracks how guessable a password is.

## The algorithm
`calculateStrength()` now works off an entropy estimate instead: how big a character pool the password draws from, multiplied by its length. That's the NIST SP 800-63B logic, basically - length and unpredictability matter more than forcing someone to add a symbol just to satisfy a rule.

Raw entropy alone isn't enough though, since it'd happily rate `aaaaaaaa` or `12345678` as fine just because they're 8 characters. So there's a penalty pass on top that knocks down anything built from lazy patterns - repeated or sequential character runs (`aaaa`, `1234`, `dcba`) plus keyboard-row walks (`qwerty`, `asdfgh`, `zxcvbn`). Added the keyboard check specifically because it's one of the most common tricks people fall back on, and the sequential check alone had no way to catch it. Only straight-row patterns are covered though, not diagonal ones like `1qaz2wsx` - could build out a full keyboard adjacency graph for that, but that would be overkill.

One more thing worth flagging: there's no dictionary or breached-password check anywhere in here. That would mean shipping a big static wordlist just to compare against, which adds a lot more data and complexity to the codebase and still wouldn't be dynamic - it'd only ever catch what's baked in at build time. Again, would be overkill, so a well-known password can still score decently if it's long or varied enough - the algorithm has no way to know it's "well-known," only that it looks unpredictable on paper.

## Everything else
Went from 3 strength levels to 5 (`VERY_WEAK` through `VERY_STRONG`) since three felt a little too coarse once the entropy math was actually driving things. Minimum password length went from 6 to 8, matching what's generally recommended these days - anything shorter is automatically `VERY_WEAK` regardless of what it contains.

On the UI side: added one new color for the `VERY_WEAK` tier, in both the light and dark theme files, and let the `VERY_STRONG` reuse the existing brand color `colorPrimaryDark` rather than inventing a second shade of green. Two new string keys cover the two new tiers (`VERY_WEAK` and `VERY_STRONG`).

## Quick check
Ran the algorithm against a spread of passwords:

```
Password                        Bits  Level        Note
-----------------------------------------------------------------------------------------------
'abc123'                        n/a   VERY_WEAK    Below min length
'12345678'                       6.6  VERY_WEAK    Pure ascending digits
'aaaaaaaa'                       9.4  VERY_WEAK    Single repeated character
'abcdefgh'                       9.4  VERY_WEAK    Ascending alphabet run
'qwertyui'                       9.4  VERY_WEAK    Keyboard row run
'asdfghjk'                       9.4  VERY_WEAK    Keyboard row run
'1qaz2wsx'                      41.4  MODERATE     Zigzag keyboard (not caught, see above)
'password'                      37.6  MODERATE     Common dictionary word
'Password1'                     53.6  MODERATE     Capitalized word + digit
'P@ssw0rd'                      52.6  MODERATE     Leet-speak substitution
'goldfish'                      37.6  MODERATE     Plain dictionary word
'helloooo'                      23.5  WEAK         Word with repeated tail
'qX9!vL2#'                      52.6  MODERATE     Random 8-char, full pool
'K7$mQ2!pXz'                    65.7  STRONG       Random 10-char, full pool
'N0tSoS1mple!'                  78.8  VERY_STRONG  Mixed passphrase, 12 chars
'correcthorsebatterystaple'    117.5  VERY_STRONG  Classic XKCD passphrase
"MyDog'sName2024!"             105.1  VERY_STRONG  Long mixed passphrase
```