### PR TITLE
Fix: Crashes caused be non empty fragment constructors

### DIFF
--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/BackupBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/BackupBottomSheetDialogFragment.kt
@@ -17,6 +17,7 @@
 package dev.leonlatsch.photok.backup.ui
 
 import android.net.Uri
+import android.os.Bundle
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.R
@@ -33,19 +34,34 @@ import dev.leonlatsch.photok.uicomponnets.base.processdialogs.BaseProcessBottomS
  * @author Leon Latsch
  */
 @AndroidEntryPoint
-class BackupBottomSheetDialogFragment(
-    private val uri: Uri,
-    private val strategy: BackupStrategy.Name
-) : BaseProcessBottomSheetDialogFragment<Photo>(
-    itemSource = null,
-    processingLabelTextResource = strategy.title,
-    canAbort = true,
-) {
+class BackupBottomSheetDialogFragment : BaseProcessBottomSheetDialogFragment<Photo>() {
+
+    private val strategy: BackupStrategy.Name by lazy {
+        BackupStrategy.Name.valueOf(requireArguments().getString(ARG_STRATEGY)!!)
+    }
+
+    override val processingLabelTextResource: Int
+        get() = strategy.title
+    override val canAbort = true
+
     override val viewModel: BackupViewModel by viewModels()
 
     override fun prepareViewModel(items: List<Photo>?) {
-        super.prepareViewModel(items)
-        viewModel.uri = uri
+        @Suppress("DEPRECATION")
+        viewModel.uri = requireArguments().getParcelable(ARG_URI)!!
         viewModel.strategyName = strategy
+    }
+
+    companion object {
+        private const val ARG_URI = "uri"
+        private const val ARG_STRATEGY = "strategy"
+
+        fun newInstance(uri: Uri, strategy: BackupStrategy.Name): BackupBottomSheetDialogFragment =
+            BackupBottomSheetDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable(ARG_URI, uri)
+                    putString(ARG_STRATEGY, strategy.name)
+                }
+            }
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreBackupDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/RestoreBackupDialogFragment.kt
@@ -19,7 +19,7 @@ package dev.leonlatsch.photok.backup.ui
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.BR
 import dev.leonlatsch.photok.R
@@ -41,7 +41,7 @@ import javax.inject.Inject
 class RestoreBackupDialogFragment() :
     BindableDialogFragment<DialogRestoreBackupBinding>(R.layout.dialog_restore_backup) {
 
-    private val viewModel: RestoreBackupViewModel by viewModels()
+    private val viewModel: RestoreBackupViewModel by activityViewModels()
 
     @Inject
     lateinit var inAppReview: InAppReview
@@ -110,10 +110,8 @@ class RestoreBackupDialogFragment() :
     }
 
     fun onRestoreAndUnlock() {
-        val unlockDialog = UnlockBackupDialogFragment(uri = uri, metaData = viewModel.metaData!!) { session ->
-                viewModel.restoreBackup(session)
-            }
-        unlockDialog.show(requireActivity().supportFragmentManager)
+        UnlockBackupDialogFragment.newInstance(uri)
+            .show(requireActivity().supportFragmentManager)
     }
 
     override fun bind(binding: DialogRestoreBackupBinding) {

--- a/app/src/main/java/dev/leonlatsch/photok/backup/ui/UnlockBackupDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/backup/ui/UnlockBackupDialogFragment.kt
@@ -19,15 +19,15 @@ package dev.leonlatsch.photok.backup.ui
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.activity.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.BR
 import dev.leonlatsch.photok.R
-import dev.leonlatsch.photok.backup.data.BackupMetaData
 import dev.leonlatsch.photok.backup.domain.UnlockBackupUseCase
 import dev.leonlatsch.photok.databinding.DialogBackupUnlockBinding
-import dev.leonlatsch.photok.encryption.domain.models.Session
 import dev.leonlatsch.photok.other.extensions.hide
 import dev.leonlatsch.photok.other.extensions.show
 import dev.leonlatsch.photok.uicomponnets.bindings.BindableDialogFragment
@@ -41,16 +41,16 @@ import javax.inject.Inject
  * @author Leon Latsch
  */
 @AndroidEntryPoint
-class UnlockBackupDialogFragment(
-    private val uri: Uri,
-    private val metaData: BackupMetaData,
-    val onUnlockSuccess: (session: Session) -> Unit
-) : BindableDialogFragment<DialogBackupUnlockBinding>(R.layout.dialog_backup_unlock) {
+class UnlockBackupDialogFragment : BindableDialogFragment<DialogBackupUnlockBinding>(R.layout.dialog_backup_unlock) {
 
     private val viewModel: UnlockBackupViewModel by viewModels()
+    private val restoreBackupViewModel: RestoreBackupViewModel by activityViewModels()
 
     @Inject
     lateinit var unlockBackupUseCase: UnlockBackupUseCase
+
+    @Suppress("DEPRECATION")
+    private val uri: Uri by lazy { requireArguments().getParcelable(ARG_URI)!! }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -63,11 +63,13 @@ class UnlockBackupDialogFragment(
     fun onUnlock() {
         binding.unlockBackupWrongPasswordWarning.hide()
 
+        val metaData = restoreBackupViewModel.metaData ?: return
+
         lifecycleScope.launch {
             unlockBackupUseCase(uri, metaData, viewModel.password)
                 .onSuccess { session ->
+                    restoreBackupViewModel.restoreBackup(session)
                     dismiss()
-                    onUnlockSuccess(session)
                 }
                 .onFailure {
                     binding.unlockBackupWrongPasswordWarning.show()
@@ -79,5 +81,16 @@ class UnlockBackupDialogFragment(
         super.bind(binding)
         binding.viewModel = viewModel
         binding.context = this
+    }
+
+    companion object {
+        private const val ARG_URI = "uri"
+
+        fun newInstance(uri: Uri): UnlockBackupDialogFragment =
+            UnlockBackupDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable(ARG_URI, uri)
+                }
+            }
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/encryption/migration/ui/EncryptionMigrationScreenInitial.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/encryption/migration/ui/EncryptionMigrationScreenInitial.kt
@@ -98,7 +98,7 @@ fun EncryptionMigrationScreenInitial(
             it ?: return@rememberLauncherForActivityResult
             if (activity !is AppCompatActivity) return@rememberLauncherForActivityResult
 
-            BackupBottomSheetDialogFragment(
+            BackupBottomSheetDialogFragment.newInstance(
                 uri = it,
                 strategy = BackupStrategy.Name.Legacy,
             ).show(activity.supportFragmentManager)

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/albums/detail/ui/AlbumDetailNavigator.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/albums/detail/ui/AlbumDetailNavigator.kt
@@ -46,7 +46,7 @@ class AlbumDetailNavigator @Inject constructor() {
         event: NavigationEvent.StartImport,
         fragmentManager: FragmentManager
     ) {
-       ImportBottomSheetDialogFragment(
+       ImportBottomSheetDialogFragment.newInstance(
            uris = event.fileUris,
            albumUUID = event.albumUuid,
            importSource = ImportSource.InApp,

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/components/ImportSharedDialog.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/components/ImportSharedDialog.kt
@@ -64,7 +64,7 @@ class ImportSharedViewModel @Inject constructor(
         when (event) {
             is ImportSharedUiEvent.ClearSharedUris -> sharedUrisStore.reset()
             is ImportSharedUiEvent.StartImportShared -> {
-                ImportBottomSheetDialogFragment(
+                ImportBottomSheetDialogFragment.newInstance(
                     uris = uiState.value.sharedUris.toList(),
                     albumUUID = null,
                     importSource = ImportSource.Share,

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/importing/ImportBottomSheetDialogFragment.kt
@@ -39,15 +39,14 @@ import javax.inject.Inject
  * @author Leon Latsch
  */
 @AndroidEntryPoint
-class ImportBottomSheetDialogFragment(
-    uris: List<Uri>,
-    private val albumUUID: String? = "",
-    private val importSource: ImportSource,
-) : BaseProcessBottomSheetDialogFragment<Uri>(
-    uris,
-    R.string.import_importing,
-    true
-) {
+class ImportBottomSheetDialogFragment : BaseProcessBottomSheetDialogFragment<Uri>() {
+
+    override val processingLabelTextResource = R.string.import_importing
+    override val canAbort = true
+    override val itemSource: List<Uri> by lazy {
+        @Suppress("DEPRECATION")
+        requireArguments().getParcelableArrayList(ARG_URIS)!!
+    }
 
     override val viewModel: ImportViewModel by viewModels()
 
@@ -64,8 +63,26 @@ class ImportBottomSheetDialogFragment(
     }
 
     override fun prepareViewModel(items: List<Uri>?) {
-        viewModel.albumUUID = albumUUID
-        viewModel.importSource = importSource
+        viewModel.albumUUID = requireArguments().getString(ARG_ALBUM_UUID)
+        viewModel.importSource = ImportSource.valueOf(requireArguments().getString(ARG_IMPORT_SOURCE)!!)
         super.prepareViewModel(items?.reversed()) // Reverse list to keep order in system gallery
+    }
+
+    companion object {
+        private const val ARG_URIS = "uris"
+        private const val ARG_ALBUM_UUID = "album_uuid"
+        private const val ARG_IMPORT_SOURCE = "import_source"
+
+        fun newInstance(
+            uris: List<Uri>,
+            albumUUID: String? = null,
+            importSource: ImportSource,
+        ): ImportBottomSheetDialogFragment = ImportBottomSheetDialogFragment().apply {
+            arguments = Bundle().apply {
+                putParcelableArrayList(ARG_URIS, ArrayList(uris))
+                putString(ARG_ALBUM_UUID, albumUUID)
+                putString(ARG_IMPORT_SOURCE, importSource.name)
+            }
+        }
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/DeleteBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/DeleteBottomSheetDialogFragment.kt
@@ -16,6 +16,7 @@
 
 package dev.leonlatsch.photok.gallery.ui.menu
 
+import android.os.Bundle
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.R
@@ -30,13 +31,25 @@ import dev.leonlatsch.photok.uicomponnets.base.processdialogs.BaseProcessBottomS
  * @author Leon Latsch
  */
 @AndroidEntryPoint
-class DeleteBottomSheetDialogFragment(
-    photos: List<Photo>
-) : BaseProcessBottomSheetDialogFragment<Photo>(
-    photos,
-    R.string.delete_deleting,
-    true
-) {
+class DeleteBottomSheetDialogFragment : BaseProcessBottomSheetDialogFragment<Photo>() {
+
+    override val processingLabelTextResource = R.string.delete_deleting
+    override val canAbort = true
 
     override val viewModel: DeleteViewModel by viewModels()
+
+    override fun prepareViewModel(items: List<Photo>?) {
+        viewModel.photoUuids = requireArguments().getStringArrayList(ARG_UUIDS)!!
+    }
+
+    companion object {
+        private const val ARG_UUIDS = "uuids"
+
+        fun newInstance(photos: List<Photo>): DeleteBottomSheetDialogFragment =
+            DeleteBottomSheetDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putStringArrayList(ARG_UUIDS, ArrayList(photos.map { it.uuid }))
+                }
+            }
+    }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/DeleteViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/DeleteViewModel.kt
@@ -35,6 +35,14 @@ class DeleteViewModel @Inject constructor(
     private val photoRepository: PhotoRepository
 ) : BaseProcessViewModel<Photo>(app) {
 
+    var photoUuids: List<String> = emptyList()
+
+    override suspend fun preProcess() {
+        items = photoUuids.map { photoRepository.get(it) }
+        elementsToProcess = items.size
+        super.preProcess()
+    }
+
     override suspend fun processItem(item: Photo) {
         if (item.uuid.isEmpty()) {
             failuresOccurred = true

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/DeleteViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/DeleteViewModel.kt
@@ -38,7 +38,7 @@ class DeleteViewModel @Inject constructor(
     var photoUuids: List<String> = emptyList()
 
     override suspend fun preProcess() {
-        items = photoUuids.map { photoRepository.get(it) }
+        items = photoRepository.get(photoUuids)
         elementsToProcess = items.size
         super.preProcess()
     }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/ExportBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/ExportBottomSheetDialogFragment.kt
@@ -17,6 +17,7 @@
 package dev.leonlatsch.photok.gallery.ui.menu
 
 import android.net.Uri
+import android.os.Bundle
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import dev.leonlatsch.photok.R
@@ -30,19 +31,29 @@ import dev.leonlatsch.photok.uicomponnets.base.processdialogs.BaseProcessBottomS
  * @author Leon Latsch
  */
 @AndroidEntryPoint
-class ExportBottomSheetDialogFragment(
-    photos: List<Photo>,
-    private val target: Uri,
-) : BaseProcessBottomSheetDialogFragment<Photo>(
-    photos,
-    R.string.export_exporting,
-    true
-) {
+class ExportBottomSheetDialogFragment : BaseProcessBottomSheetDialogFragment<Photo>() {
+
+    override val processingLabelTextResource = R.string.export_exporting
+    override val canAbort = true
 
     override val viewModel: ExportViewModel by viewModels()
 
     override fun prepareViewModel(items: List<Photo>?) {
-        super.prepareViewModel(items)
-        viewModel.target = target
+        viewModel.photoUuids = requireArguments().getStringArrayList(ARG_UUIDS)!!
+        @Suppress("DEPRECATION")
+        viewModel.target = requireArguments().getParcelable(ARG_TARGET)!!
+    }
+
+    companion object {
+        private const val ARG_UUIDS = "uuids"
+        private const val ARG_TARGET = "target"
+
+        fun newInstance(photos: List<Photo>, target: Uri): ExportBottomSheetDialogFragment =
+            ExportBottomSheetDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putStringArrayList(ARG_UUIDS, ArrayList(photos.map { it.uuid }))
+                    putParcelable(ARG_TARGET, target)
+                }
+            }
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/ExportViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/ExportViewModel.kt
@@ -40,7 +40,7 @@ class ExportViewModel @Inject constructor(
     lateinit var target: Uri
 
     override suspend fun preProcess() {
-        items = photoUuids.map { photoRepository.get(it) }
+        items = photoRepository.get(photoUuids)
         elementsToProcess = items.size
         super.preProcess()
     }

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/ExportViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/menu/ExportViewModel.kt
@@ -36,7 +36,14 @@ class ExportViewModel @Inject constructor(
     private val photoRepository: PhotoRepository
 ) : BaseProcessViewModel<Photo>(app) {
 
+    var photoUuids: List<String> = emptyList()
     lateinit var target: Uri
+
+    override suspend fun preProcess() {
+        items = photoUuids.map { photoRepository.get(it) }
+        elementsToProcess = items.size
+        super.preProcess()
+    }
 
     override suspend fun processItem(item: Photo) {
         val result = photoRepository.exportPhoto(item, target)

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/navigation/GalleryNavigator.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/navigation/GalleryNavigator.kt
@@ -46,7 +46,7 @@ class GalleryNavigator @Inject constructor() {
     }
 
     private fun startImport(fileUris: List<Uri>, fragmentManager: FragmentManager, importSource: ImportSource) {
-        ImportBottomSheetDialogFragment(
+        ImportBottomSheetDialogFragment.newInstance(
             uris = fileUris,
             albumUUID = null,
             importSource = importSource,

--- a/app/src/main/java/dev/leonlatsch/photok/gallery/ui/navigation/PhotoActionsNavigator.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/gallery/ui/navigation/PhotoActionsNavigator.kt
@@ -50,14 +50,14 @@ class PhotoActionsNavigator @Inject constructor() {
         target: Uri,
         fragmentManager: FragmentManager,
     ) {
-        ExportBottomSheetDialogFragment(photos, target).show(fragmentManager)
+        ExportBottomSheetDialogFragment.newInstance(photos, target).show(fragmentManager)
     }
 
     private fun confirmAndDelete(
         photos: List<Photo>,
         fragmentManager: FragmentManager
     ) {
-        DeleteBottomSheetDialogFragment(photos).show(fragmentManager)
+        DeleteBottomSheetDialogFragment.newInstance(photos).show(fragmentManager)
     }
 
     private fun navigateOpenPhoto(photoUUID: String, albumUUID: String, navController: NavController) {

--- a/app/src/main/java/dev/leonlatsch/photok/model/database/dao/PhotoDao.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/database/dao/PhotoDao.kt
@@ -16,11 +16,16 @@
 
 package dev.leonlatsch.photok.model.database.dao
 
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.RawQuery
 import androidx.sqlite.db.SimpleSQLiteQuery
 import androidx.sqlite.db.SupportSQLiteQuery
-import dev.leonlatsch.photok.sort.domain.Sort
 import dev.leonlatsch.photok.model.database.entity.Photo
+import dev.leonlatsch.photok.sort.domain.Sort
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -62,6 +67,14 @@ interface PhotoDao {
      */
     @Query("SELECT * FROM photo WHERE photo_uuid = :uuid")
     suspend fun get(uuid: String): Photo
+
+    /**
+     * Get one [Photo] by [id].
+     *
+     * @return the photo with [id]
+     */
+    @Query("SELECT * FROM photo WHERE photo_uuid IN (:uuids)")
+    suspend fun get(uuids: List<String>): List<Photo>
 
     /**
      * Get all photos, ordered by imported At (desc).

--- a/app/src/main/java/dev/leonlatsch/photok/model/database/entity/Photo.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/database/entity/Photo.kt
@@ -69,7 +69,5 @@ data class Photo(
         const val DATE_TAKEN = "dateTaken"
         const val COL_SIZE = "size"
         const val TABLE_NAME = "photo"
-
-
     }
 }

--- a/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/model/repositories/PhotoRepository.kt
@@ -40,7 +40,6 @@ import java.io.OutputStream
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 
 /**
@@ -78,6 +77,16 @@ class PhotoRepository @Inject constructor(
     suspend fun deleteAll() = photoDao.deleteAll()
 
     suspend fun get(uuid: String) = photoDao.get(uuid)
+
+    suspend fun get(uuids: List<String>): List<Photo> {
+        val photos = mutableListOf<Photo>()
+
+        uuids.chunked(900).forEach {
+            photos.addAll(photoDao.get(it))
+        }
+
+        return photos
+    }
 
     /**
      * @see PhotoDao.findAllPhotosByImportDateDesc

--- a/app/src/main/java/dev/leonlatsch/photok/settings/ui/compose/SettingsScreen.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/settings/ui/compose/SettingsScreen.kt
@@ -116,7 +116,7 @@ fun SettingsCallbacks(viewModel: SettingsViewModel) {
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
             uri ?: return@rememberLauncherForActivityResult
             fragment ?: return@rememberLauncherForActivityResult
-            BackupBottomSheetDialogFragment(
+            BackupBottomSheetDialogFragment.newInstance(
                 uri,
                 BackupStrategy.Name.Default
             ).show(fragment.parentFragmentManager)

--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessBottomSheetDialogFragment.kt
@@ -38,19 +38,18 @@ import kotlinx.coroutines.launch
  * Holds an [BaseProcessViewModel] which also needs to be overridden.
  * [viewModel] is abstract and needs to be set in the child.
  *
- * @param processingLabelTextResource The string resource to be displayed while processing.
  * @param T Type of elements to be processed
  *
  * @since 1.0.0
  * @author Leon Latsch
  */
-abstract class BaseProcessBottomSheetDialogFragment<T>(
-    private val itemSource: List<T>?,
-    @StringRes private val processingLabelTextResource: Int,
-    val canAbort: Boolean
-) : BindableBottomSheetDialogFragment<DialogBottomSheetProcessBinding>(
+abstract class BaseProcessBottomSheetDialogFragment<T> : BindableBottomSheetDialogFragment<DialogBottomSheetProcessBinding>(
     R.layout.dialog_bottom_sheet_process
 ) {
+    @get:StringRes
+    abstract val processingLabelTextResource: Int
+    abstract val canAbort: Boolean
+    open val itemSource: List<T>? = null
 
     /**
      * Abstract [BaseProcessViewModel].

--- a/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessViewModel.kt
+++ b/app/src/main/java/dev/leonlatsch/photok/uicomponnets/base/processdialogs/BaseProcessViewModel.kt
@@ -38,10 +38,10 @@ abstract class BaseProcessViewModel<T>(app: Application) : ObservableViewModel(a
 
     /**
      * List of [T].
-     * Gets set automatically by fragment.
+     * Set by the fragment or loaded by the ViewModel in [preProcess].
      * Gets processed in [processLoop].
      */
-    lateinit var items: List<T>
+    var items: List<T> = emptyList()
 
     /**
      * The processing state should be checked every time in [processLoop].


### PR DESCRIPTION
This fixes the most frequent crash in Photok. Some fragments had a non empty constructor, which made them not possible to be recreated.

In near future is is irrelevant once we migrate away from fragments, so these are quick and dirty fixes.
